### PR TITLE
Initialize local config and sync model settings

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -12,10 +12,326 @@ export const HARNESSCLAW_DIR = join(homedir(), '.harnessclaw')
 export const LEGACY_ENGINE_CONFIG_PATH = join(HARNESSCLAW_DIR, 'config.json')
 export const ENGINE_CONFIG_PATH = join(HARNESSCLAW_DIR, 'harnessclaw-engine.yaml')
 export const HARNESSCLAW_CONFIG_PATH = join(HARNESSCLAW_DIR, 'harnessclaw.json')
+export const HARNESSCLAW_WORKSPACE_DIR = join(HARNESSCLAW_DIR, 'workspace')
+export const HARNESSCLAW_SKILLS_DIR = join(HARNESSCLAW_WORKSPACE_DIR, 'skills')
 export const APP_RESOURCES_DIR = app.isPackaged
   ? process.resourcesPath
   : join(process.cwd(), 'resources')
 export const BUNDLED_BIN_DIR = join(APP_RESOURCES_DIR, 'bin')
+
+const HOME_DIRS = [
+  HARNESSCLAW_DIR,
+  join(HARNESSCLAW_DIR, 'bin'),
+  join(HARNESSCLAW_DIR, 'cron'),
+  join(HARNESSCLAW_DIR, 'db'),
+  join(HARNESSCLAW_DIR, 'logs'),
+  HARNESSCLAW_WORKSPACE_DIR,
+  HARNESSCLAW_SKILLS_DIR,
+]
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asPlainObject(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {}
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+function hasProviderContent(value: unknown): boolean {
+  const provider = asPlainObject(value)
+  return Boolean(
+    asString(provider.apiKey) ||
+    asString(provider.apiBase) ||
+    asString(provider.api_key) ||
+    asString(provider.base_url) ||
+    asString(provider.model),
+  )
+}
+
+function toUiProvider(value: unknown): Record<string, unknown> {
+  const provider = asPlainObject(value)
+  return {
+    apiKey: asString(provider.apiKey || provider.api_key),
+    apiBase: asString(provider.apiBase || provider.base_url),
+    model: asString(provider.model, provider.model ? '' : 'xopglm5'),
+  }
+}
+
+function toEngineProvider(value: unknown, fallbackModel = 'xopglm5'): Record<string, unknown> {
+  const provider = asPlainObject(value)
+  return {
+    api_key: asString(provider.api_key || provider.apiKey),
+    base_url: asString(provider.base_url || provider.apiBase),
+    model: asString(provider.model, fallbackModel),
+    max_tokens: typeof provider.max_tokens === 'number'
+      ? provider.max_tokens
+      : typeof provider.maxTokens === 'number'
+        ? provider.maxTokens
+        : 16384,
+  }
+}
+
+function getDefaultEngineConfig(): Record<string, unknown> {
+  return {
+    server: {
+      host: '127.0.0.1',
+      port: 8080,
+    },
+    log: {
+      level: 'info',
+      format: 'console',
+      output: 'stdout',
+    },
+    llm: {
+      default_provider: 'openai',
+      max_retries: 3,
+      api_timeout: '120s',
+      providers: {
+        openai: {
+          api_key: '',
+          base_url: '',
+          model: 'xopglm5',
+          max_tokens: 16384,
+        },
+        anthropic: {
+          api_key: '',
+          base_url: '',
+          model: '',
+          max_tokens: 16384,
+        },
+      },
+      bifrost: {
+        enabled: false,
+        provider: '',
+        model: '',
+        api_key: '',
+        base_url: '',
+      },
+    },
+    engine: {
+      max_turns: 24,
+      auto_compact_threshold: 0.8,
+      tool_timeout: '120s',
+    },
+    session: {
+      max_messages: 200,
+      idle_timeout: '30m',
+      storage: 'memory',
+    },
+    channels: {
+      websocket: {
+        enabled: true,
+        host: '0.0.0.0',
+        port: 8081,
+        path: '/ws',
+        write_buffer: 256,
+        ping_interval: '30s',
+        write_timeout: '10s',
+        max_message_size: 524288,
+        client_tools: true,
+        token: '',
+      },
+      http: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 0,
+        path: '/api/v1',
+      },
+      feishu: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 0,
+      },
+    },
+    tools: {
+      bash: {
+        enabled: true,
+        timeout: '60s',
+        sandbox: false,
+      },
+      file_read: {
+        enabled: true,
+      },
+      file_edit: {
+        enabled: true,
+      },
+      file_write: {
+        enabled: true,
+      },
+      grep: {
+        enabled: true,
+      },
+      glob: {
+        enabled: true,
+      },
+      web_fetch: {
+        enabled: true,
+        timeout: '30s',
+      },
+    },
+    permission: {
+      mode: 'default',
+      allowed_tools: [],
+      denied_tools: [],
+    },
+    skills: {
+      dirs: [HARNESSCLAW_SKILLS_DIR],
+    },
+    providers: {
+      openai: {
+        apiKey: '',
+        apiBase: '',
+        model: 'xopglm5',
+      },
+      anthropic: {
+        apiKey: '',
+        apiBase: '',
+        model: '',
+      },
+    },
+    agents: {
+      defaults: {
+        workspace: '~/.harnessclaw/workspace',
+        provider: 'openai',
+        model: 'xopglm5',
+      },
+    },
+    gateway: {
+      host: '127.0.0.1',
+      port: 18790,
+      heartbeat: {
+        enabled: true,
+        intervalS: 1800,
+      },
+    },
+    auth: {
+      mode: 'token',
+      token: '',
+    },
+    clawhub: {
+      token: '',
+    },
+  }
+}
+
+function getDefaultHarnessclawConfig(): Record<string, unknown> {
+  return {
+    ui: {
+      theme: 'system',
+    },
+  }
+}
+
+function normalizeEngineConfig(data: unknown): Record<string, unknown> {
+  const base = getDefaultEngineConfig()
+  const source = asPlainObject(data)
+  const normalized: Record<string, unknown> = {
+    ...base,
+    ...source,
+  }
+
+  const llm = {
+    ...asPlainObject(base.llm),
+    ...asPlainObject(source.llm),
+  }
+  const currentProviders = {
+    ...asPlainObject(asPlainObject(base.llm).providers),
+    ...asPlainObject(llm.providers),
+  }
+  const rootProviders = asPlainObject(source.providers)
+  const fallbackModel = asString(
+    asPlainObject(asPlainObject(source.agents).defaults).model,
+    'xopglm5',
+  )
+
+  if (hasProviderContent(rootProviders.custom)) {
+    currentProviders.openai = {
+      ...toEngineProvider(currentProviders.openai, fallbackModel),
+      ...toEngineProvider(rootProviders.custom, fallbackModel),
+    }
+  }
+
+  if (hasProviderContent(rootProviders.openai)) {
+    currentProviders.openai = {
+      ...toEngineProvider(currentProviders.openai, fallbackModel),
+      ...toEngineProvider(rootProviders.openai, fallbackModel),
+    }
+  }
+
+  if (hasProviderContent(rootProviders.anthropic)) {
+    currentProviders.anthropic = {
+      ...toEngineProvider(currentProviders.anthropic, fallbackModel),
+      ...toEngineProvider(rootProviders.anthropic, fallbackModel),
+    }
+  }
+
+  const requestedProvider = asString(llm.default_provider, 'openai')
+  const defaultProvider = requestedProvider === 'anthropic' ? 'anthropic' : 'openai'
+  if (!currentProviders[defaultProvider]) {
+    currentProviders[defaultProvider] = toEngineProvider({}, fallbackModel)
+  }
+
+  normalized.llm = {
+    ...llm,
+    default_provider: defaultProvider,
+    providers: currentProviders,
+  }
+
+  const websocket = {
+    ...asPlainObject(asPlainObject(base.channels).websocket),
+    ...asPlainObject(asPlainObject(source.channels).websocket),
+  }
+  const legacyHarnessclawChannel = asPlainObject(asPlainObject(source.channels).harnessclaw)
+  if (!('token' in websocket) && typeof legacyHarnessclawChannel.token === 'string') {
+    websocket.token = legacyHarnessclawChannel.token
+  }
+  normalized.channels = {
+    ...asPlainObject(base.channels),
+    ...asPlainObject(source.channels),
+    websocket,
+  }
+
+  normalized.providers = {
+    ...asPlainObject(base.providers),
+    ...rootProviders,
+    openai: toUiProvider(currentProviders.openai),
+    anthropic: toUiProvider(currentProviders.anthropic),
+    custom: hasProviderContent(rootProviders.custom)
+      ? toUiProvider(rootProviders.custom)
+      : toUiProvider(currentProviders.openai),
+  }
+
+  normalized.agents = {
+    ...asPlainObject(base.agents),
+    ...asPlainObject(source.agents),
+    defaults: {
+      ...asPlainObject(asPlainObject(base.agents).defaults),
+      ...asPlainObject(asPlainObject(source.agents).defaults),
+      model: fallbackModel,
+      workspace: '~/.harnessclaw/workspace',
+      provider: defaultProvider,
+    },
+  }
+
+  normalized.gateway = {
+    ...asPlainObject(base.gateway),
+    ...asPlainObject(source.gateway),
+  }
+  normalized.auth = {
+    ...asPlainObject(base.auth),
+    ...asPlainObject(source.auth),
+  }
+  normalized.clawhub = {
+    ...asPlainObject(base.clawhub),
+    ...asPlainObject(source.clawhub),
+  }
+
+  return normalized
+}
 
 export function ensureDir(dir: string): void {
   if (!existsSync(dir)) {
@@ -73,22 +389,46 @@ export function saveYamlConfig(path: string, data: unknown): { ok: boolean; erro
 }
 
 export function readHarnessclawConfig(fallback: Record<string, unknown> = {}): Record<string, unknown> {
+  if (!existsSync(HARNESSCLAW_CONFIG_PATH)) {
+    return { ...getDefaultHarnessclawConfig(), ...fallback }
+  }
   return readJsonConfig(HARNESSCLAW_CONFIG_PATH, fallback)
 }
 
 export function saveHarnessclawConfig(data: unknown): { ok: boolean; error?: string } {
-  return saveJsonConfig(HARNESSCLAW_CONFIG_PATH, data)
+  return saveJsonConfig(HARNESSCLAW_CONFIG_PATH, {
+    ...getDefaultHarnessclawConfig(),
+    ...asPlainObject(data),
+  })
 }
 
 export function readEngineConfig(fallback: Record<string, unknown> = {}): Record<string, unknown> {
   if (existsSync(ENGINE_CONFIG_PATH)) {
-    return readYamlConfig(ENGINE_CONFIG_PATH, fallback)
+    return normalizeEngineConfig(readYamlConfig(ENGINE_CONFIG_PATH, fallback))
   }
-  return readJsonConfig(LEGACY_ENGINE_CONFIG_PATH, fallback)
+  if (existsSync(LEGACY_ENGINE_CONFIG_PATH)) {
+    return normalizeEngineConfig(readJsonConfig(LEGACY_ENGINE_CONFIG_PATH, fallback))
+  }
+  return { ...normalizeEngineConfig({}), ...fallback }
 }
 
 export function saveEngineConfig(data: unknown): { ok: boolean; error?: string } {
-  return saveYamlConfig(ENGINE_CONFIG_PATH, data)
+  return saveYamlConfig(ENGINE_CONFIG_PATH, normalizeEngineConfig(data))
+}
+
+export function ensureHarnessclawHomeInitialized(): void {
+  HOME_DIRS.forEach(ensureDir)
+
+  if (!existsSync(HARNESSCLAW_CONFIG_PATH)) {
+    saveHarnessclawConfig(getDefaultHarnessclawConfig())
+  }
+
+  if (!existsSync(ENGINE_CONFIG_PATH)) {
+    const seed = existsSync(LEGACY_ENGINE_CONFIG_PATH)
+      ? readJsonConfig(LEGACY_ENGINE_CONFIG_PATH, {})
+      : {}
+    saveEngineConfig(seed)
+  }
 }
 
 // Backward-compatible aliases. Renderer and older code may still use the nanobot name.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import {
   ENGINE_CONFIG_PATH,
   resolveBundledBinaryPath,
   ensureDir,
+  ensureHarnessclawHomeInitialized,
   readEngineConfig,
   saveEngineConfig,
   readHarnessclawConfig,
@@ -295,6 +296,7 @@ function createWindow(): BrowserWindow {
 
 app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.iflytek.harnessclaw')
+  ensureHarnessclawHomeInitialized()
   ensureLoggingDirs()
   setLogThreshold(normalizeLogThreshold(asRecord(readHarnessclawConfig({})).logging?.level))
   writeAppLog('info', 'app.lifecycle', 'Application ready')

--- a/src/renderer/src/components/pages/SettingsPage.tsx
+++ b/src/renderer/src/components/pages/SettingsPage.tsx
@@ -496,6 +496,7 @@ interface ProviderConfig {
   apiKey: string
   apiBase: string | null
   extraHeaders: Record<string, string> | null
+  model?: string
 }
 
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
@@ -561,12 +562,106 @@ function getDisplayName(key: string): string {
   return PROVIDER_DISPLAY_NAMES[key] || key
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeProviderConfig(value: unknown): ProviderConfig {
+  const provider = isRecord(value) ? value : {}
+  return {
+    apiKey: typeof provider.apiKey === 'string' ? provider.apiKey : '',
+    apiBase: typeof provider.apiBase === 'string' ? provider.apiBase : null,
+    extraHeaders: isRecord(provider.extraHeaders) ? provider.extraHeaders as Record<string, string> : null,
+    model: typeof provider.model === 'string' ? provider.model : '',
+  }
+}
+
+function getInitialDefaultProvider(
+  data: Record<string, unknown>,
+  availableProviders: Record<string, ProviderConfig>
+): string | null {
+  const agentDefaults = isRecord(data.agents) && isRecord(data.agents.defaults)
+    ? data.agents.defaults
+    : {}
+  const preferredUiProvider = typeof agentDefaults.provider === 'string' ? agentDefaults.provider : ''
+  if (preferredUiProvider && availableProviders[preferredUiProvider]) {
+    return preferredUiProvider
+  }
+
+  const llm = isRecord(data.llm) ? data.llm : {}
+  const runtimeProvider = typeof llm.default_provider === 'string' ? llm.default_provider : ''
+  if (runtimeProvider === 'anthropic' && availableProviders.anthropic) {
+    return 'anthropic'
+  }
+  if (runtimeProvider === 'openai') {
+    if (availableProviders.custom && availableProviders.custom.apiKey) return 'custom'
+    if (availableProviders.openai) return 'openai'
+  }
+
+  const keys = Object.keys(availableProviders)
+  const enabledKey = keys.find((key) => availableProviders[key].apiKey)
+  return enabledKey || keys[0] || null
+}
+
+function getRuntimeProviderKey(providerKey: string | null): 'openai' | 'anthropic' {
+  return providerKey === 'anthropic' ? 'anthropic' : 'openai'
+}
+
+function buildEngineConfigForProviders(
+  baseConfig: Record<string, unknown>,
+  providers: Record<string, ProviderConfig>,
+  defaultProviderKey: string | null
+): Record<string, unknown> {
+  const runtimeProvider = getRuntimeProviderKey(defaultProviderKey)
+  const selectedKey = defaultProviderKey || 'openai'
+  const selectedProvider = providers[selectedKey] || providers.openai || providers.custom || {
+    apiKey: '',
+    apiBase: null,
+    extraHeaders: null,
+    model: '',
+  }
+  const selectedBase = selectedProvider.apiBase || PROVIDER_DEFAULT_BASES[selectedKey] || ''
+  const selectedModel = selectedProvider.model?.trim() || 'xopglm5'
+  const llm = isRecord(baseConfig.llm) ? baseConfig.llm : {}
+  const llmProviders = isRecord(llm.providers) ? llm.providers : {}
+  const currentRuntimeProvider = isRecord(llmProviders[runtimeProvider]) ? llmProviders[runtimeProvider] : {}
+  const agents = isRecord(baseConfig.agents) ? baseConfig.agents : {}
+  const agentDefaults = isRecord(agents.defaults) ? agents.defaults : {}
+
+  return {
+    ...baseConfig,
+    providers,
+    llm: {
+      ...llm,
+      default_provider: runtimeProvider,
+      providers: {
+        ...llmProviders,
+        [runtimeProvider]: {
+          ...currentRuntimeProvider,
+          api_key: selectedProvider.apiKey,
+          base_url: selectedBase,
+          model: selectedModel,
+        },
+      },
+    },
+    agents: {
+      ...agents,
+      defaults: {
+        ...agentDefaults,
+        provider: selectedKey,
+        model: selectedModel,
+      },
+    },
+  }
+}
+
 // ─── Model Section ──────────────────────────────────────────────────────────
 
 function ModelSection() {
   const [config, setConfig] = useState<Record<string, unknown> | null>(null)
   const [providers, setProviders] = useState<Record<string, ProviderConfig>>({})
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null)
+  const [defaultProvider, setDefaultProvider] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [loading, setLoading] = useState(true)
   const [showApiKey, setShowApiKey] = useState(false)
@@ -577,12 +672,15 @@ function ModelSection() {
     ;(async () => {
       try {
         const data = await window.engineConfig.read()
-        setConfig(data)
-        const p = (data.providers || {}) as Record<string, ProviderConfig>
-        setProviders(p)
-        const keys = Object.keys(p)
-        const enabledKey = keys.find((k) => p[k].apiKey)
-        setSelectedProvider(enabledKey || keys[0] || null)
+        const rawProviders = isRecord(data.providers) ? data.providers : {}
+        const normalizedProviders = Object.fromEntries(
+          Object.entries(rawProviders).map(([key, value]) => [key, normalizeProviderConfig(value)])
+        ) as Record<string, ProviderConfig>
+        const initialDefaultProvider = getInitialDefaultProvider(data, normalizedProviders)
+        setConfig(buildEngineConfigForProviders(data, normalizedProviders, initialDefaultProvider))
+        setProviders(normalizedProviders)
+        setDefaultProvider(initialDefaultProvider)
+        setSelectedProvider(initialDefaultProvider || Object.keys(normalizedProviders)[0] || null)
       } catch {
         setProviders({})
       } finally {
@@ -591,15 +689,21 @@ function ModelSection() {
     })()
   }, [])
 
+  const scheduleSave = useCallback((nextConfig: Record<string, unknown>) => {
+    setConfig(nextConfig)
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    saveTimerRef.current = setTimeout(async () => {
+      await window.engineConfig.save(nextConfig)
+    }, 500)
+  }, [])
+
   const debouncedSave = useCallback(
-    (updatedProviders: Record<string, ProviderConfig>) => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-      saveTimerRef.current = setTimeout(async () => {
-        if (!config) return
-        await window.engineConfig.save({ ...config, providers: updatedProviders })
-      }, 500)
+    (updatedProviders: Record<string, ProviderConfig>, nextDefaultProvider: string | null) => {
+      if (!config) return
+      const nextConfig = buildEngineConfigForProviders(config, updatedProviders, nextDefaultProvider)
+      scheduleSave(nextConfig)
     },
-    [config]
+    [config, scheduleSave]
   )
 
   useEffect(() => {
@@ -608,16 +712,26 @@ function ModelSection() {
 
   const updateProvider = (key: string, patch: Partial<ProviderConfig>) => {
     setProviders((prev) => {
-      const updated = { ...prev, [key]: { ...prev[key], ...patch } }
-      debouncedSave(updated)
+      const updated = { ...prev, [key]: { ...normalizeProviderConfig(prev[key]), ...patch } }
+      debouncedSave(updated, defaultProvider)
       return updated
     })
+  }
+
+  const handleSetDefaultProvider = (key: string) => {
+    setDefaultProvider(key)
+    setSelectedProvider(key)
+    setShowApiKey(false)
+    setTestState('idle')
+    if (!config) return
+    const nextConfig = buildEngineConfigForProviders(config, providers, key)
+    scheduleSave(nextConfig)
   }
 
   const handleTest = async () => {
     setTestState('testing')
     await new Promise((r) => setTimeout(r, 1200))
-    if (selectedProvider && providers[selectedProvider]?.apiKey) {
+    if (selectedProvider && providers[selectedProvider]?.apiKey && (providers[selectedProvider]?.model || '').trim()) {
       setTestState('ok')
     } else {
       setTestState('fail')
@@ -634,6 +748,7 @@ function ModelSection() {
   const selected = selectedProvider ? providers[selectedProvider] : null
   const selectedBase = selected?.apiBase || (selectedProvider ? PROVIDER_DEFAULT_BASES[selectedProvider] : '') || ''
   const previewUrl = selectedBase ? `${selectedBase}/v1/chat/completions` : ''
+  const isSelectedDefaultProvider = !!selectedProvider && selectedProvider === defaultProvider
 
   if (loading) {
     return <div className="flex items-center justify-center h-full"><Loader2 size={20} className="animate-spin text-muted-foreground" /></div>
@@ -693,8 +808,23 @@ function ModelSection() {
               <div className="flex items-center gap-2.5">
                 <h2 className="text-lg font-semibold text-foreground">{getDisplayName(selectedProvider)}</h2>
                 <Settings2 size={14} className="text-muted-foreground" />
+                {isSelectedDefaultProvider && (
+                  <span className="text-[10px] font-semibold text-status-connected bg-status-connected/15 px-2 py-0.5 rounded-full">
+                    Default
+                  </span>
+                )}
               </div>
-              <Toggle checked={!!selected.apiKey} onChange={(v) => { if (!v) updateProvider(selectedProvider, { apiKey: '' }) }} />
+              <div className="flex items-center gap-2">
+                {!isSelectedDefaultProvider && (
+                  <button
+                    onClick={() => handleSetDefaultProvider(selectedProvider)}
+                    className="h-8 px-3 text-sm font-medium rounded-md border border-border bg-card hover:bg-muted text-foreground transition-colors"
+                  >
+                    设为默认
+                  </button>
+                )}
+                <Toggle checked={!!selected.apiKey} onChange={(v) => { if (!v) updateProvider(selectedProvider, { apiKey: '' }) }} />
+              </div>
             </div>
 
             <div className="mb-6">
@@ -748,6 +878,16 @@ function ModelSection() {
             <div className="mb-6">
               <h3 className="text-sm font-semibold text-foreground mb-2">模型</h3>
               <div className="bg-card border border-border rounded-xl px-4 py-4 shadow-sm">
+                <input
+                  type="text"
+                  value={selected.model || ''}
+                  onChange={(e) => updateProvider(selectedProvider, { model: e.target.value })}
+                  placeholder="xopglm5"
+                  className="w-full h-8 px-3 text-sm bg-background border border-border rounded-md outline-none focus:ring-1 focus:ring-ring transition-shadow text-foreground placeholder:text-muted-foreground font-mono mb-3"
+                />
+                <p className="text-xs text-muted-foreground mb-3">
+                  当前默认 provider 会把这里的模型名同步写入 engine 运行配置。
+                </p>
                 <div className="flex items-center justify-center py-6 border border-dashed border-border rounded-lg">
                   <p className="text-xs text-muted-foreground">模型列表将自动从 API 地址获取</p>
                 </div>


### PR DESCRIPTION
  ## Summary                                                                                            
                                                                                                        
  This PR makes local first-run configuration self-bootstrapping and ensures model settings in the UI   
  are written back to the runtime engine config.                                                        
                                                                                                        
  ## Changes                                                                                            
                                                                                                        
  - initialize `~/.harnessclaw` and required subdirectories on startup                                  
  - create default `harnessclaw-engine.yaml` and `harnessclaw.json` when missing                        
  - normalize legacy/local config into the current engine config structure                              
  - make model settings persist to runtime fields such as:                                              
    - `llm.default_provider`                                                                            
    - `llm.providers`                                                                                   
    - `agents.defaults.provider`                                                                        
    - `agents.defaults.model`                                                                           
  - add editable model input in the settings page                                                       
                                                                                                        
  ## Why                                                                                                
                                                                                                        
  Without these changes, a clean local environment can start the app UI but fail to boot the engine     
  because required config files are missing. Also, model settings edited in the UI may not fully        
  propagate to the runtime engine config.                                                               
                                                                                                        
  ## Validation                                                                                         
                                                                                                        
  - `yarn build`                                                                                        
  - verified cold-start bootstrap by recreating `~/.harnessclaw`
  - verified the app can start and reconnect to the local engine after bootstrap  