### PR TITLE
docs: add jspector-fr HarnessClaw experience review

### DIFF
--- a/docs/reviews/jspector-fr.md
+++ b/docs/reviews/jspector-fr.md
@@ -1,0 +1,80 @@
+# HarnessClaw 体验测评：在 Linux/CI 环境里做首次上手与构建验证
+
+作者：@jspector-fr  
+日期：2026-05-23  
+场景：把 HarnessClaw 当作一个 Electron + React 桌面 agent 管理器项目，从零阅读 README、安装依赖、执行生产构建，并检查开发者首次上手路径是否顺畅。
+
+## 使用环境
+
+- Linux 容器环境
+- Node/Yarn 项目工作流
+- 已存在依赖后执行 `yarn build` 与 `yarn lint`
+- 重点观察：README 是否足够、构建是否可复现、失败信息是否可行动
+
+## 上手流程
+
+README 的主线比较清楚：项目定位、技术栈、安装、开发、构建命令都在首页能看到。对于第一次接触项目的人来说，`git clone`、`yarn install`、`yarn dev`、`yarn build` 这几步没有隐藏太多上下文，入口成本低。
+
+我先阅读了 `README.md` 和 `package.json`。项目结构也比较符合 Electron 应用预期：`src`、`resources`、`docs`、`scripts`、`electron-builder` 配置都在根目录，开发者不需要先猜主入口在哪里。
+
+## 构建结果
+
+执行：
+
+```bash
+yarn build
+```
+
+结果：构建成功。主进程、preload、renderer 三段都完成输出：
+
+- main bundle 生成成功
+- preload bundle 生成成功
+- renderer bundle 生成成功
+
+构建耗时很短，说明本地反馈速度不错，适合频繁迭代。
+
+构建过程中 Tailwind 给出一个警告：
+
+```text
+The class `delay-[100ms]` is ambiguous and matches multiple utilities.
+```
+
+这不是阻塞问题，但建议后续修一下。Tailwind 已给出替代写法：如果这是内容而不是 utility class，可以写成 `delay-&lsqb;100ms&rsqb;` 来消除歧义。对新贡献者来说，干净构建会降低误判风险。
+
+## Lint 体验
+
+执行：
+
+```bash
+yarn lint
+```
+
+结果：失败，原因不是代码 lint error，而是 ESLint 找不到配置文件：
+
+```text
+ESLint couldn't find a configuration file.
+```
+
+这点会影响首次贡献体验。`package.json` 已经暴露了 `lint` 命令，也安装了 `@electron-toolkit/eslint-config-ts`，所以开发者会自然认为 lint 是可用的。建议二选一：
+
+1. 补充 `.eslintrc` / `eslint.config.*`，让 `yarn lint` 能直接运行；或
+2. 如果暂时不维护 lint，就先从 README 或 scripts 中说明状态，避免贡献者把环境问题当成自己的问题。
+
+这是我本次体验中最明确的卡点。
+
+## 产品/项目印象
+
+HarnessClaw 的方向是清晰的：把 agent 管理、聊天、技能集成、session history 和设置集中到一个桌面端。相比只在命令行里跑 agent，桌面壳对非工程用户会更友好；相比 IDE 插件，它也更容易做独立的 agent 工作台。
+
+从仓库角度看，README 的 Reward Workflow 写得也比较透明：issue、PR、merge 后 tag/comment 的流程清楚，有助于外部贡献者理解奖励如何触发。
+
+## 可改进点
+
+1. **补齐 lint 配置**：这是最直接的开发者体验问题。
+2. **处理 Tailwind ambiguous class warning**：虽然不阻塞构建，但会让 CI/日志更干净。
+3. **README 增加 Troubleshooting 小节**：例如 Electron 原生依赖、`better-sqlite3`、Linux headless 环境能做哪些验证、不能做哪些 GUI 验证。
+4. **说明最小可验证路径**：比如“无 GUI 环境可先运行 `yarn build` 验证基础构建”，这样远程贡献者更容易参与。
+
+## 总结
+
+首次上手整体顺畅，生产构建可以成功，这是很好的基础。当前最影响贡献体验的是 `yarn lint` 暴露但不可用；如果补齐 ESLint 配置，项目对外部贡献者会更友好。我的建议是优先修 lint，其次清理 Tailwind warning，再补一段 troubleshooting 文档。


### PR DESCRIPTION
Closes #43

## Summary
- Adds a concrete HarnessClaw experience review under `docs/reviews/jspector-fr.md`.
- Covers README onboarding, production build verification, lint behavior, and actionable DX suggestions.

## Verification
- `yarn build` ✅
- `yarn lint` currently fails because ESLint configuration is missing; this is documented in the review as a DX finding.

## Reward transparency
Submitted for the open Reward issue #43. The review is based on repository onboarding and local build/lint checks; no false claim of full GUI usage is made.
