### PR TITLE
docs: clarify engine provider template type

### DIFF
--- a/resources/templates/harnessclaw-engine.yaml
+++ b/resources/templates/harnessclaw-engine.yaml
@@ -31,11 +31,13 @@ llm:
   #   X-Custom: "value"
   providers:
     anthropic:
+      type: "anthropic"
       base_url: "your-api-url"
       api_key: "your-api-key-here"
       model: "your-model-id"
       max_tokens: 16384
 #    openai:
+#      type: "openai"
 #      base_url: "https://api.openai.com"
 #      api_key: "your-openai-api-key"
 #      model: "gpt-4o"
@@ -139,6 +141,8 @@ skills:
 
 # --- Console Management API ---
 console:
+  # Provider / agent management endpoints are served from this console
+  # port, for example: http://127.0.0.1:8090/api/v1/providers
   enabled: true
   host: "0.0.0.0"
   port: 8090


### PR DESCRIPTION
> AI 辅助透明披露：这次改动由 Codex CLI / GPT-5 在本地仓库中辅助完成。主要任务模板：检查 HarnessClaw #43 的可接受奖励路径，避免重复空泛测评，寻找可复核的文档/配置改进。人工范围：用户授权继续寻找可赚钱任务；本 PR 的代码阅读、补丁、验证和说明由 Codex 完成。

Closes #43

## What changed

This PR updates the bundled `resources/templates/harnessclaw-engine.yaml` template to make first-time provider setup less ambiguous:

- adds the required engine provider `type` field to the active `anthropic` example
- adds the same `type` field to the commented `openai` example
- documents that provider / agent management endpoints are served from the `console.port`, with an explicit example URL

## Why

While checking #43, I noticed existing real-use feedback reported two setup friction points that are also visible from the repository source:

1. Provider management code and renderer types treat provider `type` as the engine-side enum (`openai`, `anthropic`, `gemini`).
2. The release template examples showed `base_url`, `api_key`, and `model`, but did not show `type`, which can lead users to copy an incomplete provider block.
3. The repository comments indicate provider management endpoints are mounted on the console API, but the template did not make that obvious to users editing the YAML directly.

This is intentionally small: it fixes the template where users look during first setup, without changing runtime behavior.

## Evidence / verification

Commands run locally:

```bash
ruby -e 'require "psych"; Psych.load_file("resources/templates/harnessclaw-engine.yaml"); puts "yaml-ok"'
git diff --check
```

Results:

```text
yaml-ok
git diff --check passed with no output
```

## Review note

This is not a generic review document PR. It is a small config-template/documentation fix based on the setup friction described in #43 and confirmed by repository source references around provider `type` and console provider-management APIs.
