### PR TITLE
fix(ci): prevent script injection in debug-issues-closed workflow

### DIFF
--- a/.github/workflows/debug-issues-closed.yml
+++ b/.github/workflows/debug-issues-closed.yml
@@ -12,12 +12,18 @@ jobs:
       contents: read
     steps:
       - name: Print issue metadata
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          REPOSITORY: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "issue_number=${{ github.event.issue.number }}"
-          echo "issue_title=${{ github.event.issue.title }}"
-          echo "issue_labels=${{ join(github.event.issue.labels.*.name, ', ') }}"
-          echo "repository=${{ github.repository }}"
-          echo "actor=${{ github.actor }}"
+          echo "issue_number=$ISSUE_NUMBER"
+          echo "issue_title=$ISSUE_TITLE"
+          echo "issue_labels=$ISSUE_LABELS"
+          echo "repository=$REPOSITORY"
+          echo "actor=$ACTOR"
 
       - name: Print event payload
         run: |


### PR DESCRIPTION
## Summary
Fixes CodeQL alert #1 (Cache Poisoning via low-privileged code injection) in `.github/workflows/debug-issues-closed.yml`.

`github.event.issue.title` was interpolated directly into a `run:` shell block. A crafted issue title could execute arbitrary code on the runner. Untrusted values now pass through `env:` and are referenced as shell variables, which is GitHub''s recommended hardening pattern.

## Test plan
- [ ] CodeQL re-scan on main dismisses the alert.
- [ ] Close an issue; verify the workflow still prints metadata correctly.