### PR TITLE
chore(ci): allow manual dispatch of debug-issues-closed workflow

### DIFF
--- a/.github/workflows/debug-issues-closed.yml
+++ b/.github/workflows/debug-issues-closed.yml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - closed
+  workflow_dispatch:
 
 jobs:
   debug-issues-closed:


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to `Debug Issues Closed` so it can be re-run manually from the Actions tab. Issue context fields will be empty on manual runs, which is fine for verifying that the shell quoting still works after the recent security fix (#62).

## Test plan
- [ ] After merge, go to Actions → Debug Issues Closed → Run workflow → verify the job succeeds.