### PR TITLE
fix(chat): prevent message hook order crash

### DIFF
--- a/src/renderer/src/components/pages/ChatPage.tsx
+++ b/src/renderer/src/components/pages/ChatPage.tsx
@@ -7704,6 +7704,33 @@ function MessageBubble({
   const isUser = message.role === 'user'
   const isSystem = message.role === 'system'
   const now = useSharedNowTicker(!isUser && !isSystem && !!message.isStreaming, 250)
+  const openFilePathPreview = useCallback(async (path: string) => {
+    try {
+      const result = await window.files.read(path)
+      const resolvedPath = result?.path || path
+      const fileName = resolvedPath.split(/[\\/]/).pop() || resolvedPath
+      onOpenFilePreview({
+        path: resolvedPath,
+        fileName,
+        operation: 'read_file',
+        content: result?.ok && typeof result.content === 'string' ? result.content : '',
+        isBinary: result?.ok ? Boolean(result.isBinary) : false,
+        previewKind: result?.ok && (result.previewKind === 'html' || result.previewKind === 'text')
+          ? result.previewKind
+          : undefined,
+      })
+    } catch (error) {
+      console.error('Failed to read file path:', error)
+      const fileName = path.split(/[\\/]/).pop() || path
+      onOpenFilePreview({ path, fileName, operation: 'read_file', content: '' })
+    }
+  }, [onOpenFilePreview])
+
+  // Link-open preference + drawer opener consumed by the markdown `a`
+  // renderer below. Lifted out of the JSX so we don't subscribe to context
+  // for every paragraph/code-block React renders.
+  const linkOpenBehavior = useContext(LinkOpenBehaviorContext)
+  const openWebPreviewFromCtx = useOpenWebPreview()
   const systemNotice = message.systemNotice
   const errorNotice = systemNotice?.kind === 'error' ? systemNotice : undefined
 
@@ -7916,34 +7943,6 @@ function MessageBubble({
   if (!isUser && !isSystem && !message.isStreaming && !hasRenderableAssistantBody) {
     return null
   }
-
-  const openFilePathPreview = useCallback(async (path: string) => {
-    try {
-      const result = await window.files.read(path)
-      const resolvedPath = result?.path || path
-      const fileName = resolvedPath.split(/[\\/]/).pop() || resolvedPath
-      onOpenFilePreview({
-        path: resolvedPath,
-        fileName,
-        operation: 'read_file',
-        content: result?.ok && typeof result.content === 'string' ? result.content : '',
-        isBinary: result?.ok ? Boolean(result.isBinary) : false,
-        previewKind: result?.ok && (result.previewKind === 'html' || result.previewKind === 'text')
-          ? result.previewKind
-          : undefined,
-      })
-    } catch (error) {
-      console.error('Failed to read file path:', error)
-      const fileName = path.split(/[\\/]/).pop() || path
-      onOpenFilePreview({ path, fileName, operation: 'read_file', content: '' })
-    }
-  }, [onOpenFilePreview])
-
-  // Link-open preference + drawer opener consumed by the markdown `a`
-  // renderer below. Lifted out of the JSX so we don't subscribe to context
-  // for every paragraph/code-block React renders.
-  const linkOpenBehavior = useContext(LinkOpenBehaviorContext)
-  const openWebPreviewFromCtx = useOpenWebPreview()
 
   const renderTextBlock = (text: string, key: string, compact = false) => (
     <div


### PR DESCRIPTION
Chat messages can briefly render as an empty non-streaming assistant bubble before later receiving text or tool activity. MessageBubble returned before later hooks in that empty state, so the next render used a different hook sequence and React blanked the page.

Constraint: React hooks must be called in the same order across every render path

Rejected: Filter empty assistant messages only in the parent timeline | leaves MessageBubble with a latent hook-order hazard for future early returns

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Keep MessageBubble hooks above conditional returns when adding message-state branches

Tested: PATH=/Users/wangqizhao/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Users/wangqizhao/.codex/tmp/arg0/codex-arg0ci4xNa:/Users/wangqizhao/google-cloud-sdk/bin:/Users/wangqizhao/.nvm/versions/node/v22.21.1/bin:/Users/wangqizhao/.local/bin:/Users/wangqizhao/Library/pnpm:/Users/wangqizhao/.bun/bin:/Users/wangqizhao/dotnet:/Users/wangqizhao/.antigravity/antigravity/bin:/opt/homebrew/opt/python@3.9/libexec/bin:/usr/local/apache-maven-3.9.6/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/wangqizhao/.cargo/bin:/var/bin:/Users/wangqizhao/.orbstack/bin:/Applications/Codex.app/Contents/Resources:/var/bin yarn build

Not-tested: Manual Electron send-message regression

## Summary

- Briefly describe the change and the main user-visible impact.

## Checklist

- [ ] I tested the related flow locally when applicable.
- [ ] I updated docs or copy if this change affects user-facing behavior.
- [ ] I linked the relevant issue, discussion, or task below.

## Linked Issue

- Closes #
- Related to #

## Reward Link

- [ ] This PR closes a reward issue.
- Reward issue: #
- Expected behavior: after merge, the linked reward issue is closed so `Claim Issue Reward` can calculate and record the reward split.

## Notes

- Add rollout notes, screenshots, follow-up work, or reviewer context here.
