### PR TITLE
Enable packaged Browser Agent by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, with versions tracked in the repository
 
 - Packaged Browser Agent now always launches the `agent-browser` binary bundled with the desktop app. Stale local engine configs that point to a bare `agent-browser` command no longer override the packaged runtime.
 - Bundled runtime lookup now requires exact platform filenames, preventing legacy fallback paths from hiding missing release assets.
+- Existing desktop configs now migrate Browser Agent to enabled once, so upgraded installs can use the packaged sidecar without manual tool configuration.
 
 ### Changed
 

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -10,6 +10,7 @@
 
 - 打包版 Browser Agent 现在始终启动桌面应用内置的 `agent-browser` 二进制。旧的本地 engine 配置即使指向裸 `agent-browser` 命令，也不会再覆盖打包运行时。
 - 内置运行时查找现在要求精确的平台文件名，避免旧 fallback 路径掩盖 release asset 缺失问题。
+- 现有桌面端配置现在会一次性迁移并启用 Browser Agent，升级安装后无需手动配置工具即可使用内置 sidecar。
 
 ### 变更
 

--- a/changelog/0.0.20/en.md
+++ b/changelog/0.0.20/en.md
@@ -2,6 +2,7 @@
 
 - Packaged Browser Agent now always launches the `agent-browser` binary bundled with the desktop app. Stale local engine configs that point to a bare `agent-browser` command no longer override the packaged runtime.
 - Bundled runtime lookup now requires exact platform filenames, preventing legacy fallback paths from hiding missing release assets.
+- Existing desktop configs now migrate Browser Agent to enabled once, so upgraded installs can use the packaged sidecar without manual tool configuration.
 
 ### Changed
 

--- a/changelog/0.0.20/zh-CN.md
+++ b/changelog/0.0.20/zh-CN.md
@@ -2,6 +2,7 @@
 
 - 打包版 Browser Agent 现在始终启动桌面应用内置的 `agent-browser` 二进制。旧的本地 engine 配置即使指向裸 `agent-browser` 命令，也不会再覆盖打包运行时。
 - 内置运行时查找现在要求精确的平台文件名，避免旧 fallback 路径掩盖 release asset 缺失问题。
+- 现有桌面端配置现在会一次性迁移并启用 Browser Agent，升级安装后无需手动配置工具即可使用内置 sidecar。
 
 ### 变更
 

--- a/resources/templates/harnessclaw-engine.yaml
+++ b/resources/templates/harnessclaw-engine.yaml
@@ -122,7 +122,7 @@ tools:
     api_key: ""          # set via CLAUDE_TOOLS_TAVILY_SEARCH_API_KEY or config_self.yaml
     # max_results: 5
   browser_agent:
-    enabled: false
+    enabled: true
     default_visibility: "hidden"
     max_steps: 30
     blocked_domains: []

--- a/scripts/engine-config-migration.test.cjs
+++ b/scripts/engine-config-migration.test.cjs
@@ -1,0 +1,179 @@
+const assert = require('node:assert/strict')
+const { mkdtempSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs')
+const { dirname, join } = require('node:path')
+const { tmpdir } = require('node:os')
+const test = require('node:test')
+const ts = require('typescript')
+const yaml = require('js-yaml')
+
+const root = join(__dirname, '..')
+
+function loadMigrationModule() {
+  const sourcePath = join(root, 'src', 'main', 'engine-config-migration.ts')
+  return loadTsModule(sourcePath, require)
+}
+
+function loadTsModule(sourcePath, moduleRequire) {
+  const source = readFileSync(sourcePath, 'utf8')
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText
+  const mod = { exports: {} }
+  const fn = new Function('require', 'module', 'exports', compiled)
+  fn(moduleRequire, mod, mod.exports)
+  return mod.exports
+}
+
+function loadConfigModule({ homeDir, dbState }) {
+  const migrationModule = loadMigrationModule()
+  const configPath = join(root, 'src', 'main', 'config.ts')
+  return loadTsModule(configPath, (id) => {
+    if (id === 'electron') {
+      return { app: { isPackaged: false } }
+    }
+    if (id === 'os') {
+      return { homedir: () => homeDir }
+    }
+    if (id === './engine-config-migration') {
+      return migrationModule
+    }
+    if (id === './db') {
+      return {
+        getConfigDocument(scope) {
+          return dbState[scope] || null
+        },
+        saveConfigDocument(input) {
+          dbState[input.scope] = {
+            scope: input.scope,
+            storage_format: input.storageFormat,
+            schema_version: input.schemaVersion || 1,
+            payload_text: input.payloadText,
+            created_at: 1,
+            updated_at: 2,
+          }
+        },
+      }
+    }
+    return require(id)
+  })
+}
+
+function createTempHome() {
+  return mkdtempSync(join(tmpdir(), 'harnessclaw-config-test-'))
+}
+
+function writeEngineConfig(homeDir, payloadText) {
+  const path = join(homeDir, '.harnessclaw', 'harnessclaw-engine.yaml')
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, payloadText, 'utf8')
+  return path
+}
+
+test('packaged engine config template enables browser agent by default', () => {
+  const template = readFileSync(join(root, 'resources', 'templates', 'harnessclaw-engine.yaml'), 'utf8')
+  const parsed = yaml.load(template)
+
+  assert.equal(parsed.tools.browser_agent.enabled, true)
+})
+
+test('migrates old yaml engine config to enable browser agent', () => {
+  const { migrateEngineConfigPayloadText } = loadMigrationModule()
+  const input = `
+tools:
+  browser_agent:
+    enabled: false
+    default_visibility: hidden
+    max_steps: 30
+`
+
+  const result = migrateEngineConfigPayloadText(input, 'yaml')
+  const parsed = yaml.load(result.payloadText)
+
+  assert.equal(result.changed, true)
+  assert.equal(parsed.tools.browser_agent.enabled, true)
+  assert.equal(parsed.tools.browser_agent.default_visibility, 'hidden')
+  assert.equal(parsed.tools.browser_agent.max_steps, 30)
+})
+
+test('migrates engine config with missing browser agent block', () => {
+  const { migrateEngineConfigPayloadText } = loadMigrationModule()
+
+  const result = migrateEngineConfigPayloadText('tools:\n  web_fetch:\n    enabled: true\n', 'yaml')
+  const parsed = yaml.load(result.payloadText)
+
+  assert.equal(result.changed, true)
+  assert.equal(parsed.tools.web_fetch.enabled, true)
+  assert.equal(parsed.tools.browser_agent.enabled, true)
+})
+
+test('migrates stored json engine config documents', () => {
+  const { migrateEngineConfigPayloadText } = loadMigrationModule()
+  const result = migrateEngineConfigPayloadText(JSON.stringify({
+    tools: {
+      browser_agent: {
+        enabled: false,
+        default_visibility: 'hidden',
+      },
+    },
+  }), 'json')
+  const parsed = JSON.parse(result.payloadText)
+
+  assert.equal(result.changed, true)
+  assert.equal(parsed.tools.browser_agent.enabled, true)
+  assert.equal(parsed.tools.browser_agent.default_visibility, 'hidden')
+})
+
+test('migrates schema 1 engine config document and file once', () => {
+  const homeDir = createTempHome()
+  const oldConfig = 'tools:\n  browser_agent:\n    enabled: false\n'
+  const engineConfigPath = writeEngineConfig(homeDir, oldConfig)
+  const dbState = {
+    engine: {
+      scope: 'engine',
+      storage_format: 'yaml',
+      schema_version: 1,
+      payload_text: oldConfig,
+      created_at: 1,
+      updated_at: 1,
+    },
+  }
+  const config = loadConfigModule({ homeDir, dbState })
+
+  const result = config.ensureEngineConfigInitialized()
+  const fileConfig = yaml.load(readFileSync(engineConfigPath, 'utf8'))
+  const storedConfig = yaml.load(dbState.engine.payload_text)
+
+  assert.equal(result.ok, true)
+  assert.equal(fileConfig.tools.browser_agent.enabled, true)
+  assert.equal(storedConfig.tools.browser_agent.enabled, true)
+  assert.equal(dbState.engine.schema_version, 2)
+})
+
+test('preserves schema 2 browser agent disabled setting', () => {
+  const homeDir = createTempHome()
+  const disabledConfig = 'tools:\n  browser_agent:\n    enabled: false\n'
+  const engineConfigPath = writeEngineConfig(homeDir, disabledConfig)
+  const dbState = {
+    engine: {
+      scope: 'engine',
+      storage_format: 'yaml',
+      schema_version: 2,
+      payload_text: disabledConfig,
+      created_at: 1,
+      updated_at: 1,
+    },
+  }
+  const config = loadConfigModule({ homeDir, dbState })
+
+  const result = config.ensureEngineConfigInitialized()
+  const fileConfig = yaml.load(readFileSync(engineConfigPath, 'utf8'))
+  const storedConfig = yaml.load(dbState.engine.payload_text)
+
+  assert.equal(result.ok, true)
+  assert.equal(fileConfig.tools.browser_agent.enabled, false)
+  assert.equal(storedConfig.tools.browser_agent.enabled, false)
+  assert.equal(dbState.engine.schema_version, 2)
+})

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -8,11 +8,14 @@ import {
   type ConfigScope,
   type ConfigStorageFormat,
 } from './db'
+import { migrateEngineConfigPayloadText } from './engine-config-migration'
 
 const yaml = require('js-yaml') as {
   load: (source: string) => unknown
   dump: (value: unknown, options?: Record<string, unknown>) => string
 }
+
+const ENGINE_CONFIG_SCHEMA_VERSION = 2
 
 export const HARNESSCLAW_DIR = join(homedir(), '.harnessclaw')
 export const ENGINE_CONFIG_PATH = join(HARNESSCLAW_DIR, 'harnessclaw-engine.yaml')
@@ -118,12 +121,14 @@ function persistConfigDocument(
   scope: ConfigScope,
   storageFormat: ConfigStorageFormat,
   payloadText: string,
+  schemaVersion?: number,
 ): { ok: boolean; error?: string } {
   try {
     saveConfigDocument({
       scope,
       storageFormat,
       payloadText,
+      schemaVersion,
     })
     return { ok: true }
   } catch (err) {
@@ -169,7 +174,11 @@ function seedAppConfigDocument(): { ok: boolean; payloadText?: string; error?: s
 function seedEngineConfigDocument(): { ok: boolean; payloadText?: string; error?: string } {
   try {
     if (existsSync(ENGINE_CONFIG_PATH)) {
-      return { ok: true, payloadText: readText(ENGINE_CONFIG_PATH) }
+      const migrated = migrateEngineConfigPayloadText(readText(ENGINE_CONFIG_PATH), 'yaml')
+      if (migrated.changed) {
+        writeText(ENGINE_CONFIG_PATH, migrated.payloadText)
+      }
+      return { ok: true, payloadText: migrated.payloadText }
     }
 
     if (!existsSync(ENGINE_CONFIG_TEMPLATE_PATH)) {
@@ -180,7 +189,70 @@ function seedEngineConfigDocument(): { ok: boolean; payloadText?: string; error?
     }
 
     copyFileSync(ENGINE_CONFIG_TEMPLATE_PATH, ENGINE_CONFIG_PATH)
-    return { ok: true, payloadText: readText(ENGINE_CONFIG_PATH) }
+    const migrated = migrateEngineConfigPayloadText(readText(ENGINE_CONFIG_PATH), 'yaml')
+    if (migrated.changed) {
+      writeText(ENGINE_CONFIG_PATH, migrated.payloadText)
+    }
+    return { ok: true, payloadText: migrated.payloadText }
+  } catch (err) {
+    return { ok: false, error: String(err) }
+  }
+}
+
+function parseConfigDocumentPayload(
+  storageFormat: ConfigStorageFormat,
+  payloadText: string,
+  fallback: Record<string, unknown>,
+): Record<string, unknown> {
+  return storageFormat === 'yaml'
+    ? parseYamlText(payloadText, fallback)
+    : parseJsonText(payloadText, fallback)
+}
+
+function engineConfigFileTextFromDocument(
+  storageFormat: ConfigStorageFormat,
+  payloadText: string,
+  fallback: Record<string, unknown>,
+): string {
+  return storageFormat === 'yaml'
+    ? payloadText
+    : serializeYaml(parseJsonText(payloadText, fallback))
+}
+
+function migrateStoredEngineConfigDocument(
+  storageFormat: ConfigStorageFormat,
+  payloadText: string,
+  schemaVersion: number,
+): { ok: boolean; payloadText: string; changed: boolean; error?: string } {
+  if (schemaVersion >= ENGINE_CONFIG_SCHEMA_VERSION) {
+    return { ok: true, payloadText, changed: false }
+  }
+
+  const migrated = migrateEngineConfigPayloadText(payloadText, storageFormat)
+  const persisted = persistConfigDocument('engine', storageFormat, migrated.payloadText, ENGINE_CONFIG_SCHEMA_VERSION)
+  return {
+    ok: persisted.ok,
+    payloadText: migrated.payloadText,
+    changed: migrated.changed,
+    error: persisted.error,
+  }
+}
+
+function migrateEngineConfigFileIfPresent(shouldMigrate: boolean): { ok: boolean; changed?: boolean; error?: string } {
+  if (!existsSync(ENGINE_CONFIG_PATH)) {
+    return { ok: true, changed: false }
+  }
+
+  if (!shouldMigrate) {
+    return { ok: true, changed: false }
+  }
+
+  try {
+    const migrated = migrateEngineConfigPayloadText(readText(ENGINE_CONFIG_PATH), 'yaml')
+    if (migrated.changed) {
+      writeText(ENGINE_CONFIG_PATH, migrated.payloadText)
+    }
+    return { ok: true, changed: migrated.changed }
   } catch (err) {
     return { ok: false, error: String(err) }
   }
@@ -216,23 +288,29 @@ export function readEngineConfig(fallback: Record<string, unknown> = {}): Record
 
   const stored = getConfigDocument('engine')
   if (stored) {
+    const shouldMigrate = stored.schema_version < ENGINE_CONFIG_SCHEMA_VERSION
+    const migrated = migrateStoredEngineConfigDocument(stored.storage_format, stored.payload_text, stored.schema_version)
+    if (!migrated.ok) return { ...fallback, _error: migrated.error || 'Unable to migrate engine config document' }
+
+    const fileMigration = migrateEngineConfigFileIfPresent(shouldMigrate)
+    if (!fileMigration.ok) return { ...fallback, _error: fileMigration.error || 'Unable to migrate engine config file' }
+
     if (!existsSync(ENGINE_CONFIG_PATH)) {
-      const syncText = stored.storage_format === 'yaml'
-        ? stored.payload_text
-        : serializeYaml(parseJsonText(stored.payload_text, fallback))
-      writeText(ENGINE_CONFIG_PATH, syncText)
+      writeText(ENGINE_CONFIG_PATH, engineConfigFileTextFromDocument(stored.storage_format, migrated.payloadText, fallback))
     }
 
-    return stored.storage_format === 'yaml'
-      ? parseYamlText(stored.payload_text, fallback)
-      : parseJsonText(stored.payload_text, fallback)
+    return parseConfigDocumentPayload(stored.storage_format, migrated.payloadText, fallback)
   }
 
-  const fileConfig = readYamlConfig(ENGINE_CONFIG_PATH, fallback)
   if (existsSync(ENGINE_CONFIG_PATH)) {
-    void persistConfigDocument('engine', 'yaml', readText(ENGINE_CONFIG_PATH))
+    const migrated = migrateEngineConfigPayloadText(readText(ENGINE_CONFIG_PATH), 'yaml')
+    if (migrated.changed) {
+      writeText(ENGINE_CONFIG_PATH, migrated.payloadText)
+    }
+    void persistConfigDocument('engine', 'yaml', migrated.payloadText, ENGINE_CONFIG_SCHEMA_VERSION)
+    return parseYamlText(migrated.payloadText, fallback)
   }
-  return fileConfig
+  return fallback
 }
 
 export function saveEngineConfig(data: unknown): { ok: boolean; error?: string } {
@@ -240,7 +318,7 @@ export function saveEngineConfig(data: unknown): { ok: boolean; error?: string }
   if (!initialized.ok) return initialized
 
   const payloadText = serializeYaml(data)
-  const persisted = persistConfigDocument('engine', 'yaml', payloadText)
+  const persisted = persistConfigDocument('engine', 'yaml', payloadText, ENGINE_CONFIG_SCHEMA_VERSION)
   if (!persisted.ok) return persisted
 
   return saveYamlConfig(ENGINE_CONFIG_PATH, data)
@@ -250,21 +328,32 @@ export function ensureEngineConfigInitialized(): { ok: boolean; created?: boolea
   ensureDir(HARNESSCLAW_DIR)
   const stored = getConfigDocument('engine')
 
-  if (stored && !existsSync(ENGINE_CONFIG_PATH)) {
-    const payloadText = stored.storage_format === 'yaml'
-      ? stored.payload_text
-      : serializeYaml(parseJsonText(stored.payload_text, {}))
-    writeText(ENGINE_CONFIG_PATH, payloadText)
-    return { ok: true, created: true }
-  }
+  if (stored) {
+    const shouldMigrate = stored.schema_version < ENGINE_CONFIG_SCHEMA_VERSION
+    const migrated = migrateStoredEngineConfigDocument(stored.storage_format, stored.payload_text, stored.schema_version)
+    if (!migrated.ok) {
+      return { ok: false, error: migrated.error }
+    }
 
-  if (existsSync(ENGINE_CONFIG_PATH) && stored) {
+    const fileMigration = migrateEngineConfigFileIfPresent(shouldMigrate)
+    if (!fileMigration.ok) {
+      return { ok: false, error: fileMigration.error }
+    }
+
+    if (!existsSync(ENGINE_CONFIG_PATH)) {
+      writeText(ENGINE_CONFIG_PATH, engineConfigFileTextFromDocument(stored.storage_format, migrated.payloadText, {}))
+      return { ok: true, created: true }
+    }
+
     return { ok: true, created: false }
   }
 
-  if (existsSync(ENGINE_CONFIG_PATH) && !stored) {
-    const payloadText = readText(ENGINE_CONFIG_PATH)
-    const persisted = persistConfigDocument('engine', 'yaml', payloadText)
+  if (existsSync(ENGINE_CONFIG_PATH)) {
+    const migrated = migrateEngineConfigPayloadText(readText(ENGINE_CONFIG_PATH), 'yaml')
+    if (migrated.changed) {
+      writeText(ENGINE_CONFIG_PATH, migrated.payloadText)
+    }
+    const persisted = persistConfigDocument('engine', 'yaml', migrated.payloadText, ENGINE_CONFIG_SCHEMA_VERSION)
     return {
       ok: persisted.ok,
       created: false,
@@ -272,17 +361,18 @@ export function ensureEngineConfigInitialized(): { ok: boolean; created?: boolea
     }
   }
 
-  const initialized = ensureConfigDocumentInitialized('engine', 'yaml', seedEngineConfigDocument)
-  if (!initialized.ok) {
-    return initialized
+  const seeded = seedEngineConfigDocument()
+  if (!seeded.ok || typeof seeded.payloadText !== 'string') {
+    return { ok: false, error: seeded.error || 'Unable to seed engine config' }
   }
 
-  const payloadText = getConfigDocument('engine')?.payload_text
-  if (typeof payloadText === 'string') {
-    writeText(ENGINE_CONFIG_PATH, payloadText)
+  const persisted = persistConfigDocument('engine', 'yaml', seeded.payloadText, ENGINE_CONFIG_SCHEMA_VERSION)
+  if (!persisted.ok) {
+    return { ok: false, error: persisted.error }
   }
 
-  return initialized
+  writeText(ENGINE_CONFIG_PATH, seeded.payloadText)
+  return { ok: true, created: true }
 }
 
 // Backward-compatible aliases. Renderer and older code may still use the nanobot name.

--- a/src/main/engine-config-migration.ts
+++ b/src/main/engine-config-migration.ts
@@ -1,0 +1,142 @@
+const yaml = require('js-yaml') as {
+  load: (source: string) => unknown
+  dump: (value: unknown, options?: Record<string, unknown>) => string
+}
+
+export type EngineConfigStorageFormat = 'json' | 'yaml'
+
+type ConfigRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is ConfigRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parsePayloadText(payloadText: string, storageFormat: EngineConfigStorageFormat): ConfigRecord | null {
+  try {
+    const parsed = storageFormat === 'json'
+      ? JSON.parse(payloadText)
+      : yaml.load(payloadText) ?? {}
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function serializeYaml(data: unknown): string {
+  const serialized = yaml.dump(data, {
+    noRefs: true,
+    lineWidth: 120,
+    sortKeys: false,
+  })
+  return serialized.endsWith('\n') ? serialized : `${serialized}\n`
+}
+
+function serializePayloadText(data: unknown, storageFormat: EngineConfigStorageFormat): string {
+  if (storageFormat === 'json') {
+    return `${JSON.stringify(data, null, 2)}\n`
+  }
+  return serializeYaml(data)
+}
+
+function ensureRecord(parent: ConfigRecord, key: string): { record: ConfigRecord; changed: boolean } {
+  const existing = parent[key]
+  if (isRecord(existing)) {
+    return { record: existing, changed: false }
+  }
+
+  const record: ConfigRecord = {}
+  parent[key] = record
+  return { record, changed: true }
+}
+
+function ensureBrowserAgentEnabled(config: ConfigRecord): boolean {
+  let changed = false
+
+  const tools = ensureRecord(config, 'tools')
+  changed = tools.changed || changed
+
+  const browserAgent = ensureRecord(tools.record, 'browser_agent')
+  changed = browserAgent.changed || changed
+
+  if (browserAgent.record.enabled !== true) {
+    browserAgent.record.enabled = true
+    changed = true
+  }
+
+  return changed
+}
+
+function lineIndent(line: string): number {
+  const match = line.match(/^(\s*)/)
+  return match ? match[1].length : 0
+}
+
+function isYamlSectionBoundary(line: string, parentIndent: number): boolean {
+  if (!line.trim() || line.trimStart().startsWith('#')) {
+    return false
+  }
+  return lineIndent(line) <= parentIndent
+}
+
+function patchYamlBrowserAgentBlock(payloadText: string): string | null {
+  const newline = payloadText.includes('\r\n') ? '\r\n' : '\n'
+  const lines = payloadText.replace(/\r\n/g, '\n').split('\n')
+  const browserAgentIndex = lines.findIndex((line) => /^\s*browser_agent:\s*(?:#.*)?$/.test(line))
+  if (browserAgentIndex < 0) return null
+
+  const browserAgentIndent = lineIndent(lines[browserAgentIndex])
+  const enabledLinePattern = /^(\s*)enabled:\s*false(\s*(?:#.*)?)?$/
+  let insertIndex = browserAgentIndex + 1
+
+  for (let index = browserAgentIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (isYamlSectionBoundary(line, browserAgentIndent)) {
+      break
+    }
+
+    insertIndex = index + 1
+    const match = line.match(enabledLinePattern)
+    if (match) {
+      lines[index] = `${match[1]}enabled: true${match[2] ?? ''}`
+      return lines.join(newline)
+    }
+  }
+
+  lines.splice(insertIndex, 0, `${' '.repeat(browserAgentIndent + 2)}enabled: true`)
+  return lines.join(newline)
+}
+
+function parsedBrowserAgentEnabled(payloadText: string, storageFormat: EngineConfigStorageFormat): boolean {
+  const parsed = parsePayloadText(payloadText, storageFormat)
+  if (!parsed) return false
+  const tools = parsed.tools
+  if (!isRecord(tools)) return false
+  const browserAgent = tools.browser_agent
+  return isRecord(browserAgent) && browserAgent.enabled === true
+}
+
+export function migrateEngineConfigPayloadText(
+  payloadText: string,
+  storageFormat: EngineConfigStorageFormat,
+): { payloadText: string; changed: boolean } {
+  const parsed = parsePayloadText(payloadText, storageFormat)
+  if (!parsed) {
+    return { payloadText, changed: false }
+  }
+
+  if (parsedBrowserAgentEnabled(payloadText, storageFormat)) {
+    return { payloadText, changed: false }
+  }
+
+  if (storageFormat === 'yaml') {
+    const patchedText = patchYamlBrowserAgentBlock(payloadText)
+    if (patchedText && parsedBrowserAgentEnabled(patchedText, storageFormat)) {
+      return { payloadText: patchedText, changed: true }
+    }
+  }
+
+  const changed = ensureBrowserAgentEnabled(parsed)
+  return changed
+    ? { payloadText: serializePayloadText(parsed, storageFormat), changed: true }
+    : { payloadText, changed: false }
+}


### PR DESCRIPTION
## Summary
- Enable Browser Agent in the bundled engine config template.
- Migrate existing desktop engine configs once, without overriding later user choices.
- Update changelog entries.

## Tests
- node --test scripts/prepare-bundled-binaries.test.cjs scripts/download-harnessclaw-runtime-release.test.cjs scripts/engine-config-migration.test.cjs
- yarn build