### PR TITLE
feat(team): show preview banner on Agent Team tab

### DIFF
--- a/src/renderer/src/components/pages/TeamPage.tsx
+++ b/src/renderer/src/components/pages/TeamPage.tsx
@@ -12,6 +12,7 @@ import {
   Cog,
   FileText,
   ImagePlus,
+  Info,
   Layers3,
   Play,
   Plus,
@@ -513,6 +514,20 @@ export function TeamPage() {
         </header>
 
         <section className="space-y-4 pt-5">
+          {activeView === 'teams' ? (
+            <div
+              role="status"
+              className="flex items-start gap-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-foreground"
+            >
+              <Info size={16} className="mt-0.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="min-w-0">
+                <p className="font-medium">{t('team.previewBanner.title')}</p>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t('team.previewBanner.description')}
+                </p>
+              </div>
+            </div>
+          ) : null}
           {activeView === 'agents' ? (
             agents.length > 0 ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -1581,6 +1581,10 @@
     "emptyAgentsDesc": "Create your first agent above to use in teams later.",
     "emptyTeams": "No Agent Teams yet",
     "emptyTeamsDesc": "Create a team to combine multiple agents into fixed collaborative groups.",
+    "previewBanner": {
+      "title": "Agent Team is in early preview",
+      "description": "Workflow design, collaboration settings, and testing steps are still coming soon. Published teams are kept only for this session and won't persist after a restart."
+    },
     "agentType": {
       "sync": "sync (Sync Sub-agent)",
       "async": "async (Async Sub-agent)",

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -1591,6 +1591,10 @@
     "emptyAgentsDesc": "从上方创建第一个角色，后续可用于 Team 组合。",
     "emptyTeams": "还没有 Agent Team",
     "emptyTeamsDesc": "创建一个 Team，把多个角色组合成固定协作编组。",
+    "previewBanner": {
+      "title": "Agent Team 处于早期预览阶段",
+      "description": "工作流设计、协作配置、测试等步骤暂未上线；已发布的团队仅在本次会话内保留，重启应用后会丢失。"
+    },
     "agentType": {
       "sync": "sync（同步子体）",
       "async": "async（异步子体）",


### PR DESCRIPTION
## Summary

Closes #78.

在 Teams tab 顶部加一个早期预览提示 banner，明确告诉用户：

- 工作流设计 / 协作配置 / 测试等 SOP 步骤目前仍是 placeholder（coming soon）
- 已发布的团队只存在于当前会话内存里，重启应用就会丢失

避免用户花十几分钟走完整个 New Team 向导（Define Goal → Members → Workflow → Collaboration → Test → Publish）才发现核心功能不可用 —— 也就是 #78 报告的体验问题。

## Changes

- `src/renderer/src/components/pages/TeamPage.tsx`: 在 `activeView === 'teams'` 时渲染一个 amber 高亮的 `role="status"` 提示卡片（沿用现有的 Tailwind 设计 token，无新依赖）。
- `src/renderer/src/locales/en.json` / `zh.json`: 新增 `team.previewBanner.title` / `team.previewBanner.description` 两条文案。

## Scope

- 不改 SOP 向导本身的任何逻辑；
- 不动后端 / 数据层；
- Agents tab 完全不受影响。

## Test plan

- [ ] 打开 Agent Team 页面，切到 "Agent Team" 子 tab，能看到顶部出现 preview banner。
- [ ] 切回 "Agents" 子 tab，banner 消失。
- [ ] 切换中 / 英文，banner 文案随之切换。
- [ ] 已有团队列表 / EmptyStateCard / SOP 向导布局未被破坏。
