### PR TITLE
fix(models): skip engine sync when toggling a model on a disabled provider

### DIFF
--- a/src/renderer/src/components/pages/SettingsPage.tsx
+++ b/src/renderer/src/components/pages/SettingsPage.tsx
@@ -3803,6 +3803,31 @@ function ModelSection({
 
     updateProvider(selectedProvider, patch)
 
+    // Skip engine sync when the provider itself isn't enabled yet.
+    //
+    // Without this guard, toggling a model on a disabled provider posts
+    // an endpoint to an engine entry that has no credentials applied,
+    // so the engine bounces the request with a misleading
+    // "API Key is Required" — even when the user already filled (and
+    // successfully tested) the API key in the form (#77).
+    //
+    // The renderer state is still updated above, so the model selection
+    // is remembered. When the user later enables the provider via
+    // handleToggleProviderEnabled, its bulk-sync pass walks
+    // `previous.models` and POSTs every enabled entry to the engine in
+    // one go — so deferring the sync here is loss-free.
+    if (!current.enabled) {
+      if (willEnable) {
+        setToastNotice({
+          tone: 'success',
+          message: t('models.validation.providerDisabledModelSaved', {
+            name: getDisplayName(selectedProvider),
+          }),
+        })
+      }
+      return
+    }
+
     // Hot-reload to the engine. Fire-and-forget; failures surface as toasts.
     // Pass the entry's tags so model_type lands in the engine the same
     // moment the endpoint is created — saves the user from having to

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -157,7 +157,8 @@
       "missingKey": "{{name}} is missing API key",
       "missingBase": "{{name}} is missing API base URL",
       "noModels": "{{name}} needs at least one model added",
-      "noneSelected": "{{name}} needs at least one model selected"
+      "noneSelected": "{{name}} needs at least one model selected",
+      "providerDisabledModelSaved": "{{name}} provider isn't enabled yet — your model selection is saved and will apply once you enable {{name}}."
     },
     "persist": {
       "readFailed": "Failed to read model config",
@@ -1080,7 +1081,8 @@
         "missingKey": "{{name}} is missing API key",
         "missingBase": "{{name}} is missing API base URL",
         "noModels": "{{name}} needs at least one model added",
-        "noneSelected": "{{name}} needs at least one model selected"
+        "noneSelected": "{{name}} needs at least one model selected",
+        "providerDisabledModelSaved": "{{name}} provider isn't enabled yet — your model selection is saved and will apply once you enable {{name}}."
       },
       "persist": {
         "readFailed": "Failed to read model config",

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -103,7 +103,8 @@
       "missingKey": "{{name}} 缺少 API 密钥",
       "missingBase": "{{name}} 缺少 API 地址",
       "noModels": "{{name}} 至少需要添加一个模型",
-      "noneSelected": "{{name}} 至少需要勾选一个模型"
+      "noneSelected": "{{name}} 至少需要勾选一个模型",
+      "providerDisabledModelSaved": "{{name}} 供应商尚未启用 —— 已保存模型选择，启用 {{name}} 后将立即生效。"
     },
     "capabilities": {
       "vision": "视觉",
@@ -1090,7 +1091,8 @@
         "missingKey": "{{name}} 缺少 API 密钥",
         "missingBase": "{{name}} 缺少 API 地址",
         "noModels": "{{name}} 至少需要添加一个模型",
-        "noneSelected": "{{name}} 至少需要勾选一个模型"
+        "noneSelected": "{{name}} 至少需要勾选一个模型",
+        "providerDisabledModelSaved": "{{name}} 供应商尚未启用 —— 已保存模型选择，启用 {{name}} 后将立即生效。"
       },
       "persist": {
         "readFailed": "模型配置读取失败",


### PR DESCRIPTION
## Summary

Closes #77.

修复 Models 页在 Provider 未启用时勾选模型会报误导性 `API Key is Required` 的问题。

## Root cause

`handleToggleModelEnabled` 会无条件触发 `hotCreateEndpoint` → 引擎 POST endpoint。在 Provider 总开关还没打开时，引擎里的 provider 条目尚未应用凭证，于是引擎以 `API Key is Required` 回绝请求 —— 哪怕用户已经填好 API key 并 test 通过，错误信息也把排查方向指向了「Key 缺失」，跟实际原因（Provider 未启用）完全无关。

## Fix

`handleToggleModelEnabled` 在更新 renderer 状态之后：

- **Provider 已启用** → 走原有的引擎同步路径（行为不变）；
- **Provider 未启用** → 跳过引擎调用：
  - renderer 状态依然保留勾选结果；
  - 若是「开启」操作，弹一条 forward-looking toast：`{provider} 供应商尚未启用 —— 已保存模型选择，启用 {provider} 后将立即生效`，把用户指向真正的开关。

后续用户开启 Provider 时，`handleToggleProviderEnabled` 的 bulk-sync 会遍历 `previous.models` 把所有已勾选模型一次性 POST 到引擎，所以这次延后同步是无损的。

## Changes

- `src/renderer/src/components/pages/SettingsPage.tsx`: 在 `handleToggleModelEnabled` 中加 Provider 启用态判断 + 友好 toast；附带解释根因的注释。
- `src/renderer/src/locales/en.json` / `zh.json`: 新增 `models.validation.providerDisabledModelSaved`（两份 validation 块都补齐，沿用现有 duplicate 结构）。

## Test plan

- [ ] 全新配置一个 Provider，填好 API key 并 test 通过；**不开启** Provider 总开关；在 Models 列表里勾选一个模型 → 不再报 `API Key is Required`，而是看到「已保存模型选择，启用 X 后将立即生效」的 toast。
- [ ] 接着开启 Provider 总开关 → 之前勾选的模型在引擎侧自动启用（bulk-sync 生效）。
- [ ] 把 Provider 总开关打开后再勾选 / 反选模型 → 行为与原先一致，引擎同步正常。
- [ ] 切换中 / 英文界面，toast 文案随之切换。
