### PR TITLE
feat(team): clarify scope of custom agents on Agents tab

### DIFF
--- a/src/renderer/src/components/pages/TeamPage.tsx
+++ b/src/renderer/src/components/pages/TeamPage.tsx
@@ -12,6 +12,7 @@ import {
   Cog,
   FileText,
   ImagePlus,
+  Info,
   Layers3,
   Play,
   Plus,
@@ -514,7 +515,25 @@ export function TeamPage() {
 
         <section className="space-y-4 pt-5">
           {activeView === 'agents' ? (
-            agents.length > 0 ? (
+            <>
+              {/* Clarify scope (#75): users expected agents created
+                  here to surface automatically in chat (Emma), but
+                  Emma dispatches the engine's built-in roles. Custom
+                  agents live in the Agent Team registry and are
+                  invoked by composing them into a Team. */}
+              <div
+                role="note"
+                className="flex items-start gap-3 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-4 py-3 text-sm text-foreground"
+              >
+                <Info size={16} className="mt-0.5 flex-shrink-0 text-sky-600 dark:text-sky-400" />
+                <div className="min-w-0">
+                  <p className="font-medium">{t('team.agentsScopeBanner.title')}</p>
+                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                    {t('team.agentsScopeBanner.description')}
+                  </p>
+                </div>
+              </div>
+              {agents.length > 0 ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {agents.map((agent) => (
                   <article
@@ -572,14 +591,15 @@ export function TeamPage() {
                   </article>
                 ))}
               </div>
-            ) : (
-              <EmptyStateCard
-                title={currentMeta.emptyTitle}
-                description={currentMeta.emptyDescription}
-                buttonLabel={currentMeta.buttonLabel}
-                onCreate={openCreateDialog}
-              />
-            )
+              ) : (
+                <EmptyStateCard
+                  title={currentMeta.emptyTitle}
+                  description={currentMeta.emptyDescription}
+                  buttonLabel={currentMeta.buttonLabel}
+                  onCreate={openCreateDialog}
+                />
+              )}
+            </>
           ) : (
             <SopWizardView
               active={sopActive}

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -1579,6 +1579,10 @@
     "newTeam": "New Agent Team",
     "emptyAgents": "No Agents yet",
     "emptyAgentsDesc": "Create your first agent above to use in teams later.",
+    "agentsScopeBanner": {
+      "title": "Custom Agents live in the Agent Team registry",
+      "description": "Agents you create here are wired into Agent Teams. The chat console (Emma) still dispatches the engine's built-in roles such as scheduler / freelancer; to invoke a custom agent, add it to a Team."
+    },
     "emptyTeams": "No Agent Teams yet",
     "emptyTeamsDesc": "Create a team to combine multiple agents into fixed collaborative groups.",
     "agentType": {

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -1589,6 +1589,10 @@
     "newTeam": "新建 Agent Team",
     "emptyAgents": "还没有角色",
     "emptyAgentsDesc": "从上方创建第一个角色，后续可用于 Team 组合。",
+    "agentsScopeBanner": {
+      "title": "自定义角色目前归 Agent Team 注册表管",
+      "description": "在这里创建的角色会接入 Agent Team。聊天台（Emma）目前调度的仍是引擎内置的 scheduler / freelancer 等角色；要调用自定义角色，请把它编入某个 Team。"
+    },
     "emptyTeams": "还没有 Agent Team",
     "emptyTeamsDesc": "创建一个 Team，把多个角色组合成固定协作编组。",
     "agentType": {


### PR DESCRIPTION
## Summary

Closes #75.

## Root cause（重新核对原始材料后）

回看 hu-qi 的截图：

- `docs/reviews/imgs/hu-qi/15-agents.png` 显示用户在 Team → Agents tab 上创建的 8 个 agent（Content Agent / Feedback Agent / GlobalDev Orchestrator / Growth PM / Launch Kit Reviewer / Market Positioning / Product Analyst / Repo Analyzer）**全都正常渲染**。
- `docs/reviews/imgs/hu-qi/14-agentNotfound.png` 是聊天界面：用户问 Emma「当前有哪些 Agent 可以使用」，Emma 的回答里只看到 `scheduler` / `freelancer` / `bash` / `read` 这些引擎内置角色。

所以「找不到」的实际语义不是「Team 里看不到」，而是 **「在聊天台用不到」**。

读代码确认：

- `TeamPage.loadAgents` 调 `console:listAgents` REST，返回的就是引擎里 source=custom 的 agent 集 —— 与截图 15 一致；
- `ChatPage` 里的 `availableSubagents` 是由引擎在 `plan.*` 事件里下发的（参见 ChatPage.tsx §6.13/§6.16 注释），不是 renderer 再调 listAgents 取的；
- 引擎的 `SubagentResolver` 决定 plan 里哪些角色「在线」，它跟 `POST /agents` 维护的注册表是分离的 —— 这是一个**引擎侧的集成缺口**，在本仓库里改不了。

## Fix

在 Team → Agents tab 顶部加一个 info banner（沿用 #78/#79 的 banner 模式，色调用 sky），把当前 scope 讲清楚：

> **Custom Agents live in the Agent Team registry**  
> Agents you create here are wired into Agent Teams. The chat console (Emma) still dispatches the engine's built-in roles such as scheduler / freelancer; to invoke a custom agent, add it to a Team.

让用户不再期望「Emma 自动看到我建的 agent」，并指向真正能调用它们的入口（Agent Team）。

## Changes

- `src/renderer/src/components/pages/TeamPage.tsx`:
  - 新增 `Info` lucide import；
  - 在 `activeView === 'agents'` 分支顶部包一层 `<>`，先渲染 banner，再 fallthrough 到原有的 agents grid / EmptyStateCard 二选一；
  - banner 上方有解释 #75 根因的代码注释。
- `src/renderer/src/locales/en.json` / `zh.json`:
  - 新增 `team.agentsScopeBanner.title` / `description` 两条文案。

无新依赖、不动后端 / 引擎 / IPC、不动数据流。

## Test plan

- [ ] 打开 Team 页面，停在 "Agents" 子 tab → 顶部能看到 sky-色 banner，说明 custom agents 的 scope；
- [ ] 切到 "Agent Team" 子 tab → 这里 banner 应该是之前 #79 的预览提示（amber 色），不是这次新加的；
- [ ] 切中 / 英文，banner 文案随之切换；
- [ ] 已有 / 空 agents 列表 / EmptyStateCard / SOP 向导布局均未被破坏。
