### PR TITLE
fix(skills): harden installed-skill loader and clarify invocation

### DIFF
--- a/src/main/skills-market.ts
+++ b/src/main/skills-market.ts
@@ -946,9 +946,16 @@ function syncInstalledSkillsToDb(): void {
   ensureDir(SKILLS_DIR)
   migrateInstalledSkillsIntoRepositoryFolders()
   const db = getDb()
-  const directories = existsSync(SKILLS_DIR)
+  // Keep the matched SKILL.md path verbatim — case is preserved by
+  // findSkillMarkdownFiles (which compares lower-cased). Recreating
+  // the path with a hard-coded uppercase `SKILL.md` would break on
+  // case-sensitive filesystems (Linux, case-sensitive APFS volumes,
+  // tarballed repos extracted with their original casing) the moment
+  // a cloned skill stores its manifest as `skill.md` or `Skill.md`
+  // — see #76 where a manually-cloned repo silently disappeared from
+  // the Skills page.
+  const skillFiles = existsSync(SKILLS_DIR)
     ? findSkillMarkdownFiles(SKILLS_DIR)
-        .map((filePath) => dirname(filePath))
         .sort((left, right) => left.localeCompare(right, 'zh-CN'))
     : []
 
@@ -992,9 +999,19 @@ function syncInstalledSkillsToDb(): void {
 
   const tx = db.transaction(() => {
     const now = Date.now()
-    directories.forEach((skillDir) => {
+    skillFiles.forEach((skillMdPath) => {
+      const skillDir = dirname(skillMdPath)
       const id = relative(SKILLS_DIR, skillDir).replace(/\\/g, '/')
-      const content = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')
+      // Isolate per-skill failures so a single unreadable / malformed
+      // SKILL.md doesn't roll back the whole transaction and leave the
+      // user with an empty Skills page (#76).
+      let content: string
+      try {
+        content = readFileSync(skillMdPath, 'utf-8')
+      } catch (error) {
+        console.error(`[Skills] Failed to read ${skillMdPath}:`, error)
+        return
+      }
       const meta = readSkillMarkdownMeta(content, id)
       const source = readInstallSource(skillDir)
       const existingBySource = source?.key ? existingBySourceKey.get(source.key) : undefined
@@ -1005,22 +1022,27 @@ function syncInstalledSkillsToDb(): void {
       }
 
       seen.add(id)
-      upsert.run({
-        id,
-        name: meta.name || id,
-        description: meta.description,
-        allowed_tools: meta.allowedTools,
-        has_references: existsSync(join(skillDir, 'references')) ? 1 : 0,
-        has_templates: existsSync(join(skillDir, 'templates')) ? 1 : 0,
-        source_key: source?.key ?? null,
-        source_repo_id: source?.repoId ?? null,
-        source_repo_name: source?.repoName ?? null,
-        source_repo_url: source?.repoUrl ?? null,
-        source_branch: source?.branch ?? null,
-        source_path: source?.path ?? null,
-        created_at: existingCreatedAt.get(id) ?? existingBySource?.created_at ?? now,
-        updated_at: now,
-      })
+      try {
+        upsert.run({
+          id,
+          name: meta.name || id,
+          description: meta.description,
+          allowed_tools: meta.allowedTools,
+          has_references: existsSync(join(skillDir, 'references')) ? 1 : 0,
+          has_templates: existsSync(join(skillDir, 'templates')) ? 1 : 0,
+          source_key: source?.key ?? null,
+          source_repo_id: source?.repoId ?? null,
+          source_repo_name: source?.repoName ?? null,
+          source_repo_url: source?.repoUrl ?? null,
+          source_branch: source?.branch ?? null,
+          source_path: source?.path ?? null,
+          created_at: existingCreatedAt.get(id) ?? existingBySource?.created_at ?? now,
+          updated_at: now,
+        })
+      } catch (error) {
+        console.error(`[Skills] Failed to upsert ${id}:`, error)
+        seen.delete(id)
+      }
     })
 
     {
@@ -1033,6 +1055,25 @@ function syncInstalledSkillsToDb(): void {
   tx()
 }
 
+// Locate a SKILL.md inside a single directory, case-insensitively.
+// Matches the case policy of findSkillMarkdownFiles so a manually-
+// cloned repo whose manifest is `skill.md` / `Skill.md` is still
+// recognised on case-sensitive filesystems (#76).
+function findSkillMarkdownInDir(skillDir: string): string | null {
+  if (!existsSync(skillDir)) return null
+  try {
+    const entries = readdirSync(skillDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.toLowerCase() === 'skill.md') {
+        return join(skillDir, entry.name)
+      }
+    }
+  } catch {
+    // ignore — caller treats null as "no manifest here".
+  }
+  return null
+}
+
 function migrateInstalledSkillsIntoRepositoryFolders(): void {
   if (!existsSync(SKILLS_DIR)) return
 
@@ -1040,7 +1081,7 @@ function migrateInstalledSkillsIntoRepositoryFolders(): void {
   directChildren.forEach((name) => {
     const skillDir = join(SKILLS_DIR, name)
     if (!statSync(skillDir).isDirectory()) return
-    if (!existsSync(join(skillDir, 'SKILL.md'))) return
+    if (!findSkillMarkdownInDir(skillDir)) return
 
     const source = readInstallSource(skillDir)
     if (!source?.repoName) return
@@ -1502,8 +1543,8 @@ export function listInstalledSkills(): SkillInfo[] {
 export function readInstalledSkill(id: string): string {
   try {
     const normalizedId = normalizeInstalledSkillId(id.trim())
-    const filePath = join(SKILLS_DIR, normalizedId, 'SKILL.md')
-    if (!existsSync(filePath)) return ''
+    const filePath = findSkillMarkdownInDir(join(SKILLS_DIR, normalizedId))
+    if (!filePath) return ''
     return readFileSync(filePath, 'utf-8')
   } catch (error) {
     console.error('[Skills] Failed to read skill:', error)

--- a/src/renderer/src/components/pages/SkillsPage.tsx
+++ b/src/renderer/src/components/pages/SkillsPage.tsx
@@ -326,6 +326,15 @@ export function SkillsPage() {
 
       <div className="relative flex-1 overflow-hidden">
         <div className="h-full overflow-y-auto p-3">
+          {skills.length > 0 && (
+            // Tell the user how to actually invoke a skill in chat (#76):
+            // hand-typed `/skill-id` is sent verbatim and the engine
+            // never applies the SKILL.md prompt. The composer's `/`
+            // autocomplete is what wires the chip → engine payload.
+            <p className="mb-3 rounded-lg border border-border bg-muted/30 px-3 py-2 text-[11px] leading-5 text-muted-foreground">
+              {t('skills.usageHint')}
+            </p>
+          )}
           {filtered.length === 0 ? (
             search ? (
               <div className="rounded-xl border border-dashed border-border p-8 text-center">

--- a/src/renderer/src/locales/en.json
+++ b/src/renderer/src/locales/en.json
@@ -314,6 +314,7 @@
     "emptyDesc": "Go to the Skill Market to pick the capabilities you need. They will appear here immediately after installation. Installing your first Skill will expand how HarnessClaw works.",
     "goToMarket": "Go to Skill Market",
     "autoAppear": "They will appear here after selection and installation",
+    "usageHint": "To invoke a skill in chat, type \"/\" in the composer and pick it from the autocomplete — typing the slash text by hand sends it as plain content, without applying the skill prompt.",
     "confirm": "Confirm",
     "cancel": "Cancel",
     "delete": "Delete",

--- a/src/renderer/src/locales/zh.json
+++ b/src/renderer/src/locales/zh.json
@@ -327,6 +327,7 @@
     "emptyDesc": "去 Skill 市场挑选需要的能力，安装后会立即出现在这里。第一次安装一个 Skill，就能开始扩展 HarnessClaw 的工作方式。",
     "goToMarket": "前往 Skill 市场",
     "autoAppear": "挑选并安装后，这里会自动出现",
+    "usageHint": "要在聊天里调用某个 skill，请在输入框打 \"/\" 后从自动补全里选 —— 手打整段斜杠文本会被当作普通内容发送，不会套用 skill 的 prompt。",
     "confirm": "确认",
     "cancel": "取消",
     "delete": "删除",


### PR DESCRIPTION
## Summary

Closes #76.

## Root cause（重新核对截图后）

回看 `docs/reviews/imgs/hu-qi/16-addSkill.png`：用户 git clone 完 globaldev-agent 后，**Skills 页其实正确显示了这个 skill**（卡片渲染、描述都对）—— 也就是 loader 实际上 work 了。

真正失败的是后续 `17-skillFail.png` / `18-gameover.png`：用户在聊天里手敲 `/globaldev-agent <github 链接>` 期望 skill 起作用，Emma 改用 `grep` / `glob` / `read` 凑活；再用自然语言「使用技能 globaldev-agent」，Emma 直接回答「没有这个工具」。

读代码定位到两个层面的问题：

### A. Skill loader 的隐藏鲁棒性问题

`syncInstalledSkillsToDb` 把 `findSkillMarkdownFiles` 返回的路径 **丢掉文件名** 后再用硬编码 `'SKILL.md'` 重建：

```ts
const directories = findSkillMarkdownFiles(SKILLS_DIR)
    .map((filePath) => dirname(filePath))   // ← 丢掉真实大小写
...
const content = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')  // ← 硬编码大写
```

而 `findSkillMarkdownFiles` 本身是 case-insensitive 匹配（`entry.name.toLowerCase() === 'skill.md'`）。在 macOS 默认卷上侥幸能跑，但**case-sensitive 文件系统（Linux、case-sensitive APFS、tar 解出来的原始 casing）**会立刻挂掉。同样的 hardcoded 大写还散落在 `migrateInstalledSkillsIntoRepositoryFolders` 和 `readInstalledSkill`。

更糟的是整段 sync 包在一个 `db.transaction` 里，**一个文件 read 抛错就回滚整批**，UI 直接返回空列表。

### B. 聊天里调用方式的认知缺口

`SkillComposerInput` 是这样工作的：用户打 `/` 打开下拉，选中后把 skill 元数据塞进 `selectedSkills` chip，发送时 `buildSkillComposerPayload` 才会拼出真正生效的 prompt 载荷。手敲 `/globaldev-agent foo` 这段文本会被原样发出去 —— 引擎根本不知道是要 invoke skill。UI 上没有任何提示告诉用户这一点。

## Fix

### Main: 加固 loader

- `syncInstalledSkillsToDb` 改成保留 `findSkillMarkdownFiles` 返回的完整路径，直接用真实 casing 读文件 —— case-sensitive 文件系统不再误伤；
- 每个 skill 的 read / upsert 各自 try/catch，单个 SKILL.md 损坏 / IO 失败不再回滚整个 batch；
- 新增 `findSkillMarkdownInDir` helper，让 `readInstalledSkill` 和 `migrateInstalledSkillsIntoRepositoryFolders` 也走 case-insensitive 查找。

### Renderer: 加调用方式提示

- Skills 页 grid 上方加一行 muted 风格说明：「要在聊天里调用某个 skill，请在输入框打 `/` 后从自动补全里选 —— 手打整段斜杠文本会被当作普通内容发送，不会套用 skill 的 prompt。」
- 仅在已安装 skill 数 > 0 时展示，空状态下不会喧宾夺主。

## Changes

- `src/main/skills-market.ts`：
  - `syncInstalledSkillsToDb` 改造（变量名 / 路径来源 / 双 try-catch / 注释解释 #76 根因）；
  - 新增 `findSkillMarkdownInDir`；
  - `migrateInstalledSkillsIntoRepositoryFolders` / `readInstalledSkill` 改用新 helper。
- `src/renderer/src/components/pages/SkillsPage.tsx`：grid 之上加 `usageHint` 提示行（含解释 #76 的代码注释）。
- `src/renderer/src/locales/en.json` / `zh.json`：新增 `skills.usageHint` 文案。

不动 IPC / preload / 调度链路。

## Test plan

- [ ] 手动 `cd ~/.harnessclaw/workspace/skills && git clone <一个含 SKILL.md 的仓库>` → 重启 / 刷新 Skills 页，能看到 skill；
- [ ] 模拟一个目录有大小写不一致的 manifest（如 `skill.md` 小写）在 case-sensitive FS 上 → 仍能被发现和读取；
- [ ] 故意让某个 SKILL.md 不可读（chmod 000）→ 该 skill 被跳过、其余 skill 仍然正常入库（不再整批回滚）；
- [ ] Skills 页非空时顶部能看到 usage hint；空状态下不显示；
- [ ] 中 / 英文切换，hint 文案随之切换；
- [ ] 在聊天里 `/`-触发自动补全选中 skill → 调用正常（不动这部分逻辑，纯验证未回归）。
