### PR TITLE
docs: mention Corepack for Yarn setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Harnessclaw is a powerful, Electron-based desktop application designed to manage
 - Node.js (v18 or higher recommended)
 - Yarn package manager
 
+If `yarn` is not available globally, use Corepack, which ships with recent
+Node.js releases:
+
+```bash
+corepack yarn --version
+```
+
 ### Installation
 
 Clone the repository and install the dependencies:
@@ -37,7 +44,7 @@ Clone the repository and install the dependencies:
 ```bash
 git clone https://github.com/harnessclaw/harnessclaw.git
 cd harnessclaw
-yarn install
+corepack yarn install
 ```
 
 ### Development
@@ -45,7 +52,7 @@ yarn install
 Start the application in development mode:
 
 ```bash
-yarn dev
+corepack yarn dev
 ```
 
 ### Build & Release
@@ -53,13 +60,13 @@ yarn dev
 To build the application for your local platform:
 
 ```bash
-yarn build
-yarn dist
+corepack yarn build
+corepack yarn dist
 ```
 
 To build for specific platforms:
-- Mac: `yarn dist:mac`
-- Windows: `yarn dist:win`
+- Mac: `corepack yarn dist:mac`
+- Windows: `corepack yarn dist:win`
 
 Commit, release, and changelog rules are documented in [docs/release-rules.md](./docs/release-rules.md).
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,6 +30,12 @@ Harnessclaw 是一款基于 Electron 构建的强大桌面应用程序，旨在�
 - Node.js (推荐 v18 或更高版本)
 - Yarn 包管理器
 
+如果本机没有全局 `yarn` 命令，可以使用新版 Node.js 自带的 Corepack：
+
+```bash
+corepack yarn --version
+```
+
 ### 安装
 
 克隆仓库并安装依赖：
@@ -37,7 +43,7 @@ Harnessclaw 是一款基于 Electron 构建的强大桌面应用程序，旨在�
 ```bash
 git clone https://github.com/harnessclaw/harnessclaw.git
 cd harnessclaw
-yarn install
+corepack yarn install
 ```
 
 ### 开发
@@ -45,7 +51,7 @@ yarn install
 在开发模式下启动应用程序：
 
 ```bash
-yarn dev
+corepack yarn dev
 ```
 
 ### 构建与发布
@@ -53,13 +59,13 @@ yarn dev
 构建适用于本地平台的应用程序：
 
 ```bash
-yarn build
-yarn dist
+corepack yarn build
+corepack yarn dist
 ```
 
 构建特定平台的应用程序：
-- Mac: `yarn dist:mac`
-- Windows: `yarn dist:win`
+- Mac: `corepack yarn dist:mac`
+- Windows: `corepack yarn dist:win`
 
 提交、版本与更新日志规则请见 [docs/release-rules.md](./docs/release-rules.md)。
 


### PR DESCRIPTION
AI-assisted disclosure: this PR was prepared with OpenAI Codex. Main prompt: complete Reward #66 by doing a real HarnessClaw usage pass, make a substantive repo contribution if a concrete issue is found, and disclose the evidence. Human/user-side edits were limited to authorizing the task; the changes and validation below were produced during the Codex run.

Closes #66

## What changed

During the Windows first-run test, `yarn` was not available as a global command even though Node.js/Corepack was installed. The documented setup path therefore failed at the first command for a fresh Windows environment.

This PR updates both README files to show the Corepack-backed Yarn commands that were used successfully:

- `corepack yarn --version`
- `corepack yarn install`
- `corepack yarn dev`
- `corepack yarn build`
- `corepack yarn dist*`

## Reward #66 short review

I tested HarnessClaw from a fresh clone on Windows in a real local workflow rather than only reading the docs. The first concrete friction point was setup: `yarn install` failed because `yarn` was not on PATH, while `corepack` was available with Node.js. Running `corepack yarn install` completed successfully, including `electron-builder install-app-deps` and the `better-sqlite3` native dependency rebuild. `corepack yarn build` then produced the Electron main/preload/renderer bundles successfully.

I also launched the app with `corepack yarn dev`. The app opened as `HarnessClaw` at the Electron renderer URL `http://localhost:5173/`, generated local runtime files under `~/.harnessclaw`, and displayed the first-run UI in Chinese. The initial state was clear but important: `HarnessClaw 未连接`, with visible entry points for 首页, Skill, 对话, 项目, 团队, 设置, plus onboarding steps such as 认识 Emma / 选择推理引擎 / 配置连接信息 / 选择任务画像.

Because no model connection was configured, a full agent run was not possible. I then used the running app's exposed renderer APIs for a non-model-dependent Skill workflow. In the live app process, I created a local session and used the Skill API to add and scan a public skills repository:

```json
{
  "session_id": "review-66-codex-1780992391398",
  "title": "Reward #66 使用测评证据会话",
  "harnessclaw_status": "disconnected",
  "skill_repo": "https://github.com/addyosmani/agent-skills",
  "skill_repo_base_path": "skills",
  "discovered_count": 23,
  "installed_skill": "addyosmani-agent-skills/api-and-interface-design"
}
```

The Skill flow was the strongest part of the first-run experience: repository metadata was saved, discovery found 23 skills, preview returned the `SKILL.md` content, and installation produced an installed skill record with source metadata. The weak point is discoverability: when the app is disconnected, the chat box is still prominent, but the user needs to understand that Skill discovery and setup can still be exercised without an agent connection. The README setup note in this PR addresses the first hard blocker I hit before reaching that point.

## Validation

- `corepack yarn install`
- `corepack yarn build`
- `corepack yarn dev`
- Live app generated `~/.harnessclaw/db/harnessclaw.db` and `~/.harnessclaw/log/latest.log`
- Live Skill API discovered 23 skills and installed `addyosmani-agent-skills/api-and-interface-design`