### PR TITLE
chore: remediate dependabot security alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,9 +5091,9 @@ undici-types@~6.21.0:
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^6.25.0:
-  version "6.26.0"
-  resolved "https://registry.npmmirror.com/undici/-/undici-6.26.0.tgz"
-  integrity sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==
+  version "6.27.0"
+  resolved "https://registry.npmmirror.com/undici/-/undici-6.27.0.tgz"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unified@^11.0.0:
   version "11.0.5"


### PR DESCRIPTION
Bumps `undici` 6.26.0 → 6.27.0 (transitive via electron-builder → node-gyp). Range `^6.25.0` already permits 6.27.0, so this is a lockfile-only change.

Fixes 3 open Dependabot alerts:
- #49 (medium) HTTP header injection via Set-Cookie percent-decoding
- #50 (low) HTTP response queue poisoning via keep-alive socket reuse
- #51 (low) Set-Cookie SameSite attribute downgrade via permissive substring matching