### PR TITLE
docs(readme): add download section and release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,25 @@
 
 [English](./README.md) | [简体中文](./README_zh.md)
 
+[![Release](https://img.shields.io/github/v/release/harnessclaw/harnessclaw?include_prereleases)](https://github.com/harnessclaw/harnessclaw/releases)
+[![Downloads](https://img.shields.io/github/downloads/harnessclaw/harnessclaw/total)](https://github.com/harnessclaw/harnessclaw/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 **Harnessclaw, your agent is ready.**
 
 Harnessclaw is a powerful, Electron-based desktop application designed to manage, chat with, and operate AI agents and skills seamlessly.
 
+## Download
+
+Ready-to-run builds are published on the [**Releases**](https://github.com/harnessclaw/harnessclaw/releases/latest) page:
+
+| Platform | File |
+|---|---|
+| macOS (Apple Silicon) | `HarnessClaw-<version>-mac-arm64.dmg` |
+| macOS (Intel) | `HarnessClaw-<version>-mac-x64.dmg` |
+| Windows (x64) | `HarnessClaw-<version>-win-x64.exe` |
+
+Installed builds update themselves - the app checks for new releases on start and
+installs them in the background, so you only need to download once.
 ## Features
 
 - 🤖 **Agent Management**: Easily manage and configure your AI agents.
@@ -24,6 +39,8 @@ Harnessclaw is a powerful, Electron-based desktop application designed to manage
 - **Database**: [Better SQLite3](https://github.com/JoshuaWise/better-sqlite3)
 
 ## Getting Started
+
+> Building from source is only needed for development. To just use the app, see [Download](#download).
 
 ### Prerequisites
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,10 +4,24 @@
 
 [English](./README.md) | [简体中文](./README_zh.md)
 
+[![Release](https://img.shields.io/github/v/release/harnessclaw/harnessclaw?include_prereleases)](https://github.com/harnessclaw/harnessclaw/releases)
+[![Downloads](https://img.shields.io/github/downloads/harnessclaw/harnessclaw/total)](https://github.com/harnessclaw/harnessclaw/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 **Harnessclaw, your agent is ready. (你的专属智能体已就绪)**
 
 Harnessclaw 是一款基于 Electron 构建的强大桌面应用程序，旨在帮助用户无缝地管理、对话以及操作 AI 智能体（Agents）和技能（Skills）。
 
+## 下载安装
+
+开箱即用的安装包发布在 [**Releases**](https://github.com/harnessclaw/harnessclaw/releases/latest) 页面：
+
+| 平台 | 文件 |
+|---|---|
+| macOS（Apple 芯片） | `HarnessClaw-<version>-mac-arm64.dmg` |
+| macOS（Intel） | `HarnessClaw-<version>-mac-x64.dmg` |
+| Windows（x64） | `HarnessClaw-<version>-win-x64.exe` |
+
+安装后的版本会自动更新——应用启动时会检查新版本并在后台完成安装，因此只需下载一次。
 ## 主要功能
 
 - 🤖 **智能体管理**：轻松管理和配置你的 AI 智能体。
@@ -24,6 +38,8 @@ Harnessclaw 是一款基于 Electron 构建的强大桌面应用程序，旨在�
 - **数据库**: [Better SQLite3](https://github.com/JoshuaWise/better-sqlite3)
 
 ## 快速开始
+
+> 从源码构建仅用于开发。只想使用应用请见 [下载安装](#下载安装)。
 
 ### 环境要求
 


### PR DESCRIPTION
## Problem

HarnessClaw ships installers - the latest release carries macOS `.dmg`/`.zip` for both Apple Silicon and Intel plus a Windows `.exe` - but the README's only install path was `git clone` + `yarn install` + `yarn dev`. Someone landing on the repo to *use* the app had no way to find a build, and the first screen gave no signal that packaged releases exist at all.

## Change

`README.md` and `README_zh.md`, first screen only:

1. **Badges** - latest release, total downloads, license (same license badge style the engine repo uses)
2. **`## Download` section** placed before Features, with a platform/file table for the three published artifacts and a note that installed builds self-update
3. **A pointer on `Getting Started`** clarifying that the source build is for development, with a link to Download

## Verification

- Artifact names taken from the assets on `v0.0.23`: `HarnessClaw-0.0.23-mac-arm64.dmg`, `-mac-x64.dmg`, `-win-x64.exe`; version is written as `<version>` so the table does not go stale
- No Linux row, since no Linux artifact is published
- The self-update claim is backed by `electron-updater ^6.3.9` in `package.json` and the `autoUpdater` usage in `src/main/updater.ts` / `src/main/index.ts`

Docs-only change; both language versions kept in sync.