### PR TITLE
docs(contributing): add contribution guide and README onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Harnessclaw
+
+[English](./CONTRIBUTING.md) | [简体中文](./CONTRIBUTING_zh.md)
+
+Thanks for taking the time to contribute! Whether you found us through the docs, a YouTube walkthrough, or the community group, this guide gets you from "just cloned it" to "PR merged" as quickly as possible.
+
+If Harnessclaw is useful to you, the single most helpful thing you can do is **⭐ star the repo** — it is how new people find the project.
+
+## Ways to Contribute
+
+You do not need to write code to help:
+
+- 🐛 **Report a bug** — open an [Issue](https://github.com/harnessclaw/harnessclaw/issues) with steps to reproduce, your OS, and the app version.
+- 💡 **Suggest a feature** — start a thread in [Discussions](https://github.com/harnessclaw/harnessclaw/discussions) so we can shape it together.
+- 📖 **Improve docs** — fix a typo, clarify a step, or translate a page. Doc-only PRs are very welcome and are the easiest first contribution.
+- 🛠️ **Fix an issue** — pick up something labeled [`good first issue`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+- 💰 **Claim a reward** — some issues carry a bounty (see [Reward Workflow](#reward-workflow) below).
+
+## Your First Pull Request
+
+### 1. Set up the project
+
+```bash
+# Fork the repo on GitHub, then clone your fork
+git clone https://github.com/<your-username>/harnessclaw.git
+cd harnessclaw
+yarn install
+yarn dev          # launches the app in development mode
+```
+
+Requirements: Node.js v18+ and Yarn. If `yarn dev` starts and the window opens, you are ready.
+
+### 2. Create a branch
+
+```bash
+git checkout -b fix/short-description
+```
+
+### 3. Make your change
+
+- Keep the change focused — one logical change per PR.
+- Match the surrounding code style. Run `yarn lint` before you commit.
+- If your change is user-visible, update the changelog (see [docs/release-rules.md](./docs/release-rules.md)).
+
+### 4. Commit
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) and require a **DCO sign-off** on every commit:
+
+```bash
+git commit -s -m "fix(chat): keep scroll position when a new message arrives"
+```
+
+The `-s` flag adds the `Signed-off-by` line required by our CI check. Commit types and scopes are documented in [docs/release-rules.md](./docs/release-rules.md).
+
+### 5. Push and open a PR
+
+```bash
+git push origin fix/short-description
+```
+
+Open the PR against `main`, fill in the template (summary, checklist, linked issue), and a maintainer will review it. Draft PRs are fine if you want early feedback.
+
+## Commit & Changelog Rules
+
+The full commit convention, changelog structure, and release process live in **[docs/release-rules.md](./docs/release-rules.md)**. The essentials:
+
+- Commit messages follow `type(scope): summary` (`feat`, `fix`, `docs`, `refactor`, `chore`, `build`, `ci`, `test`).
+- Every commit is signed off with `git commit -s`.
+- Do **not** hand-edit `CHANGELOG.md` / `CHANGELOG_zh.md`; edit the sources under `changelog/` and run `yarn changelog:build`.
+
+## Reward Workflow
+
+Some issues carry a bounty so contributors get paid for their work:
+
+- Maintainers open an issue with the `Reward Task` template and set the amount/currency.
+- When your PR closes that issue and is merged, a GitHub Action creates a `reward-<issue-number>` tag and comments the split on the issue.
+- On the first day of each month, the reward tags from the previous month are aggregated into a `statistic-YYYY-MM` release.
+
+Look for open issues with the `reward` label to find paid tasks.
+
+## Code of Conduct
+
+Be respectful and constructive. We want Harnessclaw to be a welcoming place for first-time and experienced contributors alike. Harassment or dismissive behavior is not tolerated.
+
+## Questions?
+
+- 💬 [GitHub Discussions](https://github.com/harnessclaw/harnessclaw/discussions) for ideas and questions
+- 🐛 [Issues](https://github.com/harnessclaw/harnessclaw/issues) for bugs and tasks
+
+Welcome aboard — we are glad you are here. 🎉

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,0 +1,90 @@
+# 为 Harnessclaw 贡献
+
+[English](./CONTRIBUTING.md) | [简体中文](./CONTRIBUTING_zh.md)
+
+感谢你抽出时间参与贡献！无论你是通过文档、YouTube 视频还是社区群了解到我们，这份指南都会帮你用最快的速度，从「刚 clone 下来」走到「PR 被合并」。
+
+如果 Harnessclaw 对你有帮助，最能支持我们的一件小事就是 **⭐ 给仓库点个 Star** —— 这是新用户发现这个项目的主要途径。
+
+## 贡献方式
+
+不写代码也能帮上忙：
+
+- 🐛 **报告 Bug** —— 提一个 [Issue](https://github.com/harnessclaw/harnessclaw/issues)，附上复现步骤、操作系统和应用版本。
+- 💡 **提出想法** —— 在 [Discussions](https://github.com/harnessclaw/harnessclaw/discussions) 里发起讨论，我们一起把它打磨清楚。
+- 📖 **完善文档** —— 修一个错别字、讲清一个步骤、翻译一个页面。纯文档 PR 非常受欢迎，也是最容易上手的第一次贡献。
+- 🛠️ **修复 Issue** —— 认领带有 [`good first issue`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 或 [`help wanted`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) 标签的任务。
+- 💰 **领取赏金** —— 部分 Issue 带有赏金（见下方 [Reward 流程](#reward-流程)）。
+
+## 你的第一个 Pull Request
+
+### 1. 准备项目
+
+```bash
+# 先在 GitHub 上 Fork 本仓库，再 clone 你的 Fork
+git clone https://github.com/<你的用户名>/harnessclaw.git
+cd harnessclaw
+yarn install
+yarn dev          # 以开发模式启动应用
+```
+
+环境要求：Node.js v18+ 和 Yarn。只要 `yarn dev` 能启动并弹出窗口，你就准备好了。
+
+### 2. 新建分支
+
+```bash
+git checkout -b fix/short-description
+```
+
+### 3. 修改代码
+
+- 保持改动聚焦 —— 一个 PR 只做一件事。
+- 与周围代码风格保持一致，提交前先跑 `yarn lint`。
+- 如果改动对用户可见，记得更新 changelog（见 [docs/release-rules.md](./docs/release-rules.md)）。
+
+### 4. 提交
+
+我们使用 [Conventional Commits](https://www.conventionalcommits.org/) 规范，并要求每个 commit 都带 **DCO 签名**：
+
+```bash
+git commit -s -m "fix(chat): keep scroll position when a new message arrives"
+```
+
+`-s` 会加上 CI 检查所要求的 `Signed-off-by` 行。提交类型与 scope 详见 [docs/release-rules.md](./docs/release-rules.md)。
+
+### 5. 推送并发起 PR
+
+```bash
+git push origin fix/short-description
+```
+
+向 `main` 分支发起 PR，按模板填写（改动摘要、检查项、关联 Issue），维护者会进行 Review。如果想尽早获得反馈，也可以先发 Draft PR。
+
+## 提交与 Changelog 规则
+
+完整的提交规范、changelog 结构和发布流程都在 **[docs/release-rules.md](./docs/release-rules.md)**。核心要点：
+
+- 提交信息遵循 `type(scope): summary`（`feat`、`fix`、`docs`、`refactor`、`chore`、`build`、`ci`、`test`）。
+- 每个 commit 都用 `git commit -s` 签名。
+- **不要**手改 `CHANGELOG.md` / `CHANGELOG_zh.md`；请编辑 `changelog/` 下的源文件再执行 `yarn changelog:build`。
+
+## Reward 流程
+
+部分 Issue 带有赏金，让贡献者的付出得到回报：
+
+- 维护者用 `Reward Task` 模板新建 Issue，并填写金额与币种。
+- 当你的 PR 合并并关闭该 Issue 后，GitHub Action 会创建 `reward-<issue-number>` 标签，并把奖励拆分结果评论回 Issue。
+- 每个月第一天，上个月的 reward 标签会被汇总为一条 `statistic-YYYY-MM` 的统计 release。
+
+想找付费任务，可以关注带 `reward` 标签的开放 Issue。
+
+## 行为准则
+
+请保持尊重与建设性。我们希望 Harnessclaw 对新手和资深贡献者都是一个友好的地方，不容忍任何骚扰或轻视他人的行为。
+
+## 有问题？
+
+- 💬 [GitHub Discussions](https://github.com/harnessclaw/harnessclaw/discussions)：想法与提问
+- 🐛 [Issues](https://github.com/harnessclaw/harnessclaw/issues)：Bug 与任务
+
+欢迎加入 —— 很高兴有你在。🎉

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Commit, release, and changelog rules are documented in [docs/release-rules.md](.
 - On the first day of each month, GitHub Actions aggregates last month's reward tags and publishes a `statistic-YYYY-MM` release summary.
 - These automations use the default `GITHUB_TOKEN`; no extra personal access token is required for the current workflows.
 
+## Contributing
+
+We welcome contributions of every size — code, docs, bug reports, and ideas. New here? Start with a [`good first issue`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), or just fix a typo. The full walkthrough — setup, first PR, commit rules, and paid reward tasks — is in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+If Harnessclaw is useful to you, please ⭐ **star the repo** — it is how new people find us.
+
 ## 📞 Support
 
 - 💬 Community Discussion: [GitHub Discussions](https://github.com/harnessclaw/harnessclaw/discussions)

--- a/README_zh.md
+++ b/README_zh.md
@@ -70,6 +70,12 @@ yarn dist
 - 每个月第一天，GitHub Actions 会汇总上个月的 reward 标签，并发布一条 `statistic-YYYY-MM` 的统计 release。
 - 当前这两条 workflow 直接使用仓库默认的 `GITHUB_TOKEN`，不需要额外配置个人 access token。
 
+## 参与贡献
+
+我们欢迎任何形式的贡献 —— 代码、文档、Bug 反馈和想法都可以。第一次参与？可以从 [`good first issue`](https://github.com/harnessclaw/harnessclaw/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 入手，或者只是修一个错别字。完整流程 —— 环境搭建、第一个 PR、提交规范、以及带赏金的 Reward 任务 —— 都在 [CONTRIBUTING_zh.md](./CONTRIBUTING_zh.md)。
+
+如果 Harnessclaw 对你有帮助，欢迎 ⭐ **给仓库点个 Star** —— 这是新用户发现我们的主要途径。
+
 ## 📞 Support
 
 - 💬 Community Discussion: [GitHub Discussions](https://github.com/harnessclaw/harnessclaw/discussions)


### PR DESCRIPTION
## Summary

Adds a bilingual contribution guide and links it prominently from both READMEs, giving newcomers (especially visitors arriving from docs/videos) a clear path from clone to merged PR.

- New `CONTRIBUTING.md` / `CONTRIBUTING_zh.md`: ways to contribute, first-PR walkthrough (fork → `yarn install` → `yarn dev` → branch → `git commit -s` → PR), commit/DCO rules linking `docs/release-rules.md`, and the reward/bounty workflow.
- `README.md` / `README_zh.md`: new Contributing section before Support, with `good first issue` links and a star ask.

Verified both labels (`good first issue`, `help wanted`) already exist, and issue #66 is already tagged `good first issue`, so the README filter links resolve to real content.

## Checklist

- [x] I tested the related flow locally when applicable. (docs-only)
- [x] I updated docs or copy if this change affects user-facing behavior.
- [x] I linked the relevant issue, discussion, or task below.

## Linked Issue

- Related to #66

## Notes

Docs-only change; no code or changelog impact.
